### PR TITLE
chore(v3.0.0): New node support matrix (#45)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 13.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
BREAKING CHANGE:
End of support for nodejs 8.x (LTS). Versions of glossarify-md >= 3.0.0
may continue to work with nodejs 8.x but may also begin to use JS language
features and APIs earliest available with nodejs 10.x LTS. Such changes
may be introduced with any new version including bugfix versions and without
notice or classification of being breaking changes to nodejs 8.x users.
New node support matrix see #45.