### PR TITLE
Disable nightly tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,8 @@ name: Run Tests
 on:
   push:
   pull_request:
-  schedule:
-  - cron: '0 23 * * *'
+#  schedule:
+#  - cron: '0 23 * * *'
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Originally enabled to detect random failures requiring a few runs.
Tests stable since addressing platform differences with paths.
Now save that energy. 
Testing on pushs and pulls should be mostly sufficient.