### PR TITLE
Refactor linking by reference definitions

### DIFF
--- a/conf/v5/doc/schema-defs-linking.md
+++ b/conf/v5/doc/schema-defs-linking.md
@@ -135,11 +135,11 @@ Negative values may also be helpful when using 'glossaries' option with a glob p
 
 *   Type: `integer`
 
-## byReference
+## byReferenceDefinition
 
 When 'true' replaces markdown inline links with numbered references to a link reference definition list at the bottom of a markdown file. See 'Link Reference Definitions' on <http://commonmark.org>.
 
-`byReference`
+`byReferenceDefinition`
 
 *   is optional
 

--- a/conf/v5/doc/schema-properties-linking.md
+++ b/conf/v5/doc/schema-properties-linking.md
@@ -22,7 +22,7 @@ The default value is:
   "headingIdAlgorithm": "github",
   "headingIdPandoc": false,
   "headingAsLink": true,
-  "byReference": true,
+  "byReferenceDefinition": true,
   "limitByAlternatives": 10
 }
 ```
@@ -164,11 +164,11 @@ Negative values may also be helpful when using 'glossaries' option with a glob p
 
 *   Type: `integer`
 
-## byReference
+## byReferenceDefinition
 
 When 'true' replaces markdown inline links with numbered references to a link reference definition list at the bottom of a markdown file. See 'Link Reference Definitions' on <http://commonmark.org>.
 
-`byReference`
+`byReferenceDefinition`
 
 *   is optional
 

--- a/conf/v5/doc/schema.md
+++ b/conf/v5/doc/schema.md
@@ -224,7 +224,7 @@ The default value is:
   "headingIdAlgorithm": "github",
   "headingIdPandoc": false,
   "headingAsLink": true,
-  "byReference": true,
+  "byReferenceDefinition": true,
   "limitByAlternatives": 10
 }
 ```
@@ -824,11 +824,11 @@ Negative values may also be helpful when using 'glossaries' option with a glob p
 
 *   Type: `integer`
 
-### byReference
+### byReferenceDefinition
 
 When 'true' replaces markdown inline links with numbered references to a link reference definition list at the bottom of a markdown file. See 'Link Reference Definitions' on <http://commonmark.org>.
 
-`byReference`
+`byReferenceDefinition`
 
 *   is optional
 

--- a/conf/v5/schema.json
+++ b/conf/v5/schema.json
@@ -88,7 +88,7 @@
                 ,"headingIdAlgorithm": "github"
                 ,"headingIdPandoc": false
                 ,"headingAsLink": true
-                ,"byReference": true
+                ,"byReferenceDefinition": true
                 ,"limitByAlternatives": 10
             }
         }
@@ -327,7 +327,7 @@
                     ,"minimum": "-95"
                     ,"maximum": "+95"
                 }
-                ,"byReference": {
+                ,"byReferenceDefinition": {
                     "description": "When 'true' replaces markdown inline links with numbered references to a link reference definition list at the bottom of a markdown file. See 'Link Reference Definitions' on http://commonmark.org."
                     ,"type": "boolean"
                 }

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -111,7 +111,7 @@ export function readDocumentFiles(context) {
                 .use(linker, { context })
                 .use(indexer, { context, indexes: [...termsIndexes, ...anchorIndexes ]})
                 .use(whenTrue(reportNotMentioned || dev.termsFile, counter), { context })
-                .use(whenTrue(linking.byReference, remark_ref_links))
+                .use(whenTrue(linking.byReferenceDefinition, remark_ref_links))
                 .use(whenTrue(linking.headingAsLink, remark_link_headings), {behavior: "wrap"})
                 .use(whenTrue(linking.headingIdPandoc, pandoc_heading_append_id))
                 .use(whenTrue(dev.printOutputAst, printAst), { match: dev.printOutputAst })

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -134,7 +134,7 @@ export function writeMarkdownFile(context, vFile) {
             .use(remark_stringify) // compiler
             .use(identifier, { algorithm: linking.headingIdAlgorithm })
             .use(remark_footnotes, {inlineNotes: true})
-            .use(whenTrue(linking.byReference, remark_ref_links))
+            .use(whenTrue(linking.byReferenceDefinition, remark_ref_links))
             .use(whenTrue(linking.headingAsLink, remark_link_headings), {behavior: "wrap"})
             .use(whenTrue(linking.headingIdPandoc, pandoc_heading_append_id));
         processor.data(unifiedConf);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debug-config": "npm run dconfig",
     "docs": "npm-run-all docs-*",
     "docs-doc": "node ./bin/index.js --config ./glossarify-md.conf.json",
-    "docs-config": "jsonschema2md -n -d ./conf/v5 -e json -o ./conf/v5/doc -x - -h=false -s nullablefact -s typesection -s definedinfact -s proptable",
+    "docs-config": "rm -r ./conf/v5/doc && jsonschema2md -n -d ./conf/v5 -e json -o ./conf/v5/doc -x - -h=false -s nullablefact -s typesection -s definedinfact -s proptable",
     "docs-repo": "remark md/README.md > README.md && remark md/CONTRIBUTING.md > CONTRIBUTING.md",
     "fix": "eslint . --fix",
     "linter": "eslint .",


### PR DESCRIPTION
Rename option `linking.byReference` to `linking.byReferenceDefinition` to use correct [CommonMark terminology](https://spec.commonmark.org/0.30/#link-reference-definition).