### PR TITLE
fix: Additionally sort by file name if 'conf.glossaries' index isn't decisive

### DIFF
--- a/lib/model/context.js
+++ b/lib/model/context.js
@@ -110,7 +110,12 @@ function unglobGlossaries(context) {
             // In terms of options like 'termHints', 'exports', only one wins.
             const keys = {};
             return confsAll
-                .sort((c1, c2) =>  c2.arrIdx - c1.arrIdx)
+                .sort((c1, c2) =>  {
+                    const byPos = c2.arrIdx - c1.arrIdx;
+                    return byPos === 0
+                        ? c2.file.localeCompare(c1.file.length, "en")
+                        : byPos;
+                })
                 .filter(conf => {
                     const filePath = conf.file;
                     if (keys[filePath]) {


### PR DESCRIPTION
...to gain reproducable test results and avoid random test failures.