### PR TITLE
210 new node support matrix

### DIFF
--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 17.x]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/tests-latest.yml
+++ b/.github/workflows/tests-latest.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 17.x]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/README.md
+++ b/README.md
@@ -861,12 +861,13 @@ Advanced topics on importing and exporting can be found [here](https://github.co
 
 The term *support* refers to *runs on the given platform* and is subject to the terms and conditions in [LICENSE](#license).
 
-|  NodeJS  |                                                                      compatibility & support status                                                                      |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Current  | Tested. Should node.js introduce breaking changes which affect [glossarify-md], then we may choose to step back from supporting *Current* until it becomes the next LTS. |
-| 14.x LTS | Tested + Supported                                                                                                                                                       |
-| 12.x LTS | Tested + Supported                                                                                                                                                       |
-| 10.x LTS | glossarify-md <= v4                                                                                                                                                      |
+| NodeJS  | glossarify-md |                                                                           Current Test Matrix                                                                            |
+| ------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Current | v6+           | Tested. Should node.js introduce breaking changes which affect [glossarify-md], then we may choose to step back from supporting *Current* until it becomes the next LTS. |
+| 16 LTS  | v5, v6+       | Tested + Supported                                                                                                                                                       |
+| 14 LTS  | v4, v5, v6+   | Tested + Supported                                                                                                                                                       |
+| 12 LTS  | v3, v4, v5    |                                                                                                                                                                          |
+| 10 LTS  | v2, v3, v4    |                                                                                                                                                                          |
 
 ## Options
 

--- a/md/README.md
+++ b/md/README.md
@@ -810,12 +810,13 @@ Advanced topics on importing and exporting can be found [here](https://github.co
 
 The term *support* refers to *runs on the given platform* and is subject to the terms and conditions in [LICENSE](#license).
 
-|  NodeJS  |                                                                      compatibility & support status                                                                      |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Current  | Tested. Should node.js introduce breaking changes which affect [glossarify-md], then we may choose to step back from supporting *Current* until it becomes the next LTS. |
-| 14.x LTS | Tested + Supported                                                                                                                                                       |
-| 12.x LTS | Tested + Supported                                                                                                                                                       |
-| 10.x LTS | glossarify-md <= v4                                                                                                                                                      |
+| NodeJS  | glossarify-md |                                                                           Current Test Matrix                                                                            |
+| ------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Current | v6+           | Tested. Should node.js introduce breaking changes which affect [glossarify-md], then we may choose to step back from supporting *Current* until it becomes the next LTS. |
+| 16 LTS  | v5, v6+       | Tested + Supported                                                                                                                                                       |
+| 14 LTS  | v4, v5, v6+   | Tested + Supported                                                                                                                                                       |
+| 12 LTS  | v3, v4, v5    |                                                                                                                                                                          |
+| 10 LTS  | v2, v3, v4    |                                                                                                                                                                          |
 
 ## Options
 


### PR DESCRIPTION
BREAKING CHANGE: glossarify-md@6.0.0 ends support for Node 12.x.

Closes #210.