### PR TITLE
feat(indexFiles): New option `generateFiles.indexFile(s).hideDeepLinks`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,21 +855,27 @@ Paths or Glob-Patterns of files to exclude. Excluded files will be excluded from
 
 #### `generateFiles.indexFile`
 
-- **Range:** `{file: string, [title: string]}`
+[doc-config-indexFile]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-generatefiles-properties-indexfile.md
+
+- **Range:** `{file: string, [title: string], [hideDeepLinks: boolean]}` ([details][doc-config-indexFile])
 - **Since:** v3.0.0
 
 Generates an index of glossary terms with links to files in which they have been mentioned.
 
 #### `generateFiles.indexFiles`
 
-- **Range:** `Array<{file: string, glossary: string, [title: string]}>`
+[doc-config-indexFiles]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-generatefiles-properties-indexfiles-items.md
+
+- **Range:** `Array<{file: string, glossary: string, [title: string], [hideDeepLinks: boolean]}>` ([details][doc-config-indexFiles])
 - **Since:** v3.0.0
 
-Similar to `indexFile` but allows for generating an index per glossary.
+Similar to `indexFile` but allows for generating multiple index files, e.g. one per glossary.
 
 #### `generateFiles.listOf`
 
-- **Range:** `Array<{class: string, file: string, [title: string]}>`
+[doc-config-listOf]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-generatefiles-properties-listof-items.md
+
+- **Range:** `Array<{class: string, file: string, [title: string]}>` ([details][doc-config-listof])
 - **Since:** v3.5.0
 
 If available, generates a list from HTML anchors exposing the configured `class` attribute.
@@ -918,17 +924,21 @@ sequence. If you would like to have the glossary sorted provide a *sort* directi
 
 #### `glossaries[].export`
 
-- **Range:** `{ file: string [, context: string]} | Array<{ file: string [, context: string]}>`
+[doc-config-exports]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-glossaryfile-properties-export-oneof-0.md
+
+- **Range:** `{ file: string [, context: string]} | Array<{ file: string [, context: string]}>` (\[details]\[doc-config-export])
 - **Since:** v6.0.0
 
 Export markdown terms in a structured JSON format. More read [here][doc-export-import].
 
 #### `glossaries[].import`
 
-- **Range:** `{ file: string [, context: string]}`
+[doc-config-import]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-glossaryfile-properties-import.md
+
+- **Range:** `{ file: string [, context: string]}` ([details][doc-config-import])
 - **Since:** v6.0.0
 
-Import terms from a structured JSON format and generate a markdown glossary from it. More read [here][doc-export-import].
+Import terms from a structured JSON format and generate a markdown glossary from it. For an example see [here][doc-export-import].
 
 #### `glossaries[].linkUris`
 

--- a/README.md
+++ b/README.md
@@ -924,9 +924,9 @@ sequence. If you would like to have the glossary sorted provide a *sort* directi
 
 #### `glossaries[].export`
 
-[doc-config-exports]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-glossaryfile-properties-export-oneof-0.md
+[doc-config-export]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-glossaryfile-properties-export-oneof-0.md
 
-- **Range:** `{ file: string [, context: string]} | Array<{ file: string [, context: string]}>` (\[details]\[doc-config-export])
+- **Range:** `{ file: string [, context: string]} | Array<{ file: string [, context: string]}>` ([details][doc-config-export])
 - **Since:** v6.0.0
 
 Export markdown terms in a structured JSON format. More read [here][doc-export-import].

--- a/conf/v5/doc/schema-defs-generatefiles-properties-indexfile.md
+++ b/conf/v5/doc/schema-defs-generatefiles-properties-indexfile.md
@@ -8,17 +8,7 @@ Path relative to 'outDir' where to create the index markdown file.
 
 `file`
 
-*   is optional
-
-*   Type: `string`
-
-## class
-
-The class is used to compile lists of content elements. Elements with a common class will be compiled into the same list.
-
-`class`
-
-*   is optional
+*   is required
 
 *   Type: `string`
 
@@ -34,10 +24,20 @@ The page title for the index file. If missing the application uses a default val
 
 ## glossary
 
-Path to a particular glossary file with terms to restrict the index document to. Only affects Index generation with 'indexFiles' property. Since v5.1.0.
+When you configured multiple glossaries, then this option can be used to generate an index file with terms of a particular glossary, only. Use with `generateFiles.indexFiles` (not `generateFiles.indexFile`). Since v5.1.0.
 
 `glossary`
 
 *   is optional
 
 *   Type: `string`
+
+## hideDeepLinks
+
+When this is `false` (default) then term occurrences in sections deeper than `indexing.groupByHeadingDepth` will be represented as short numeric links attached to a parent heading at depth `indexing.groupByHeadingDepth`. With this option being `true` you can disable these "deep" section links. Note that index file generation also depends on the kind of headings being indexed *at all* (see `indexing.headingDepths`). Since v6.1.0.
+
+`hideDeepLinks`
+
+*   is optional
+
+*   Type: `boolean`

--- a/conf/v5/doc/schema-defs-generatefiles-properties-indexfiles-items.md
+++ b/conf/v5/doc/schema-defs-generatefiles-properties-indexfiles-items.md
@@ -8,17 +8,7 @@ Path relative to 'outDir' where to create the index markdown file.
 
 `file`
 
-*   is optional
-
-*   Type: `string`
-
-## class
-
-The class is used to compile lists of content elements. Elements with a common class will be compiled into the same list.
-
-`class`
-
-*   is optional
+*   is required
 
 *   Type: `string`
 
@@ -34,10 +24,20 @@ The page title for the index file. If missing the application uses a default val
 
 ## glossary
 
-Path to a particular glossary file with terms to restrict the index document to. Only affects Index generation with 'indexFiles' property. Since v5.1.0.
+When you configured multiple glossaries, then this option can be used to generate an index file with terms of a particular glossary, only. Use with `generateFiles.indexFiles` (not `generateFiles.indexFile`). Since v5.1.0.
 
 `glossary`
 
 *   is optional
 
 *   Type: `string`
+
+## hideDeepLinks
+
+When this is `false` (default) then term occurrences in sections deeper than `indexing.groupByHeadingDepth` will be represented as short numeric links attached to a parent heading at depth `indexing.groupByHeadingDepth`. With this option being `true` you can disable these "deep" section links. Note that index file generation also depends on the kind of headings being indexed *at all* (see `indexing.headingDepths`). Since v6.1.0.
+
+`hideDeepLinks`
+
+*   is optional
+
+*   Type: `boolean`

--- a/conf/v5/doc/schema-defs-glossaryfile-properties-import.md
+++ b/conf/v5/doc/schema-defs-glossaryfile-properties-import.md
@@ -11,3 +11,13 @@ The JSON file to import terms from.
 *   is required
 
 *   Type: `string`
+
+## context
+
+File path or URL to a custom JSON-LD context document. Expected to map attributes and type names of a custom import document format onto terms of the well-known W3C SKOS vocabulary.
+
+`context`
+
+*   is optional
+
+*   Type: `string`

--- a/conf/v5/doc/schema-defs-glossaryfile.md
+++ b/conf/v5/doc/schema-defs-glossaryfile.md
@@ -63,7 +63,7 @@ If present, sort terms in output glossary. Default: None. See also i18n options.
 
 ## showUris
 
-Whether to render a term's URI in the glossary (currently for imported glossaries, only).
+Whether to render a term's URI in the glossary (currently for imported glossaries, only). May be a markdown snippet using a placeholder `${uri}` to control URI formatting.
 
 `showUris`
 

--- a/conf/v5/doc/schema-defs-glossaryfileimport.md
+++ b/conf/v5/doc/schema-defs-glossaryfileimport.md
@@ -11,3 +11,13 @@ The JSON file to import terms from.
 *   is required
 
 *   Type: `string`
+
+## context
+
+File path or URL to a custom JSON-LD context document. Expected to map attributes and type names of a custom import document format onto terms of the well-known W3C SKOS vocabulary.
+
+`context`
+
+*   is optional
+
+*   Type: `string`

--- a/conf/v5/doc/schema-defs-indexfile.md
+++ b/conf/v5/doc/schema-defs-indexfile.md
@@ -8,17 +8,7 @@ Path relative to 'outDir' where to create the index markdown file.
 
 `file`
 
-*   is optional
-
-*   Type: `string`
-
-## class
-
-The class is used to compile lists of content elements. Elements with a common class will be compiled into the same list.
-
-`class`
-
-*   is optional
+*   is required
 
 *   Type: `string`
 
@@ -34,10 +24,20 @@ The page title for the index file. If missing the application uses a default val
 
 ## glossary
 
-Path to a particular glossary file with terms to restrict the index document to. Only affects Index generation with 'indexFiles' property. Since v5.1.0.
+When you configured multiple glossaries, then this option can be used to generate an index file with terms of a particular glossary, only. Use with `generateFiles.indexFiles` (not `generateFiles.indexFile`). Since v5.1.0.
 
 `glossary`
 
 *   is optional
 
 *   Type: `string`
+
+## hideDeepLinks
+
+When this is `false` (default) then term occurrences in sections deeper than `indexing.groupByHeadingDepth` will be represented as short numeric links attached to a parent heading at depth `indexing.groupByHeadingDepth`. With this option being `true` you can disable these "deep" section links. Note that index file generation also depends on the kind of headings being indexed *at all* (see `indexing.headingDepths`). Since v6.1.0.
+
+`hideDeepLinks`
+
+*   is optional
+
+*   Type: `boolean`

--- a/conf/v5/doc/schema-defs-indexing.md
+++ b/conf/v5/doc/schema-defs-indexing.md
@@ -20,8 +20,7 @@ Level of detail by which to group occurrences of terms or syntactic elements in 
 
 ## headingDepths
 
-An array with items in a range of 1-6 denoting the depths of headings that should be indexed. Excluding some headings from indexing is mostly a performance optimization, only. You can just remove the option from your config or stick with defaults. Change defaults only if you are sure that you do not want to have cross-document links onto headings at a particular depth, no matter whether the link was created automatically or written manually.
-The relation to 'linking.headingDepths' is that *this* is about "knowing the link targets" whereas the other is about "creating links" ...based on knowledge about link targets. Yet, indexing of headings is further required for existing (cross-)links like `[foo](#heading-id)` and resolving the path to where a heading with such id was declared, so for example `[foo](../document.md#heading-id)`.
+An array with items in a range of 1-6 denoting the depths of headings that should be indexed for cross-linking. Excluding headings from indexing is mostly a performance optimization, applicable when only headings at a particular depth should participate in id-based cross-linking or term-based auto linking. Note that it is possible to keep indexing all headings to support manually written id-based cross-links for all headings but restricting auto-linking to a subset of headings at a particular depth using `linking.headingDepths` (see `linking` options).
 
 `headingDepths`
 

--- a/conf/v5/doc/schema-defs-linking.md
+++ b/conf/v5/doc/schema-defs-linking.md
@@ -71,7 +71,7 @@ Control the link density and whether every occurrence of a term in your document
 
 ## headingDepths
 
-An array of numerical values each in a range of 1-6 denoting the depths of headings that should participate in term-based link creation ("linkification"). In case you have modified 'indexing.headingDepths', be aware that 'linking.headingDepths' makes only sense if it is a full subset of the items in 'indexing.headingDepths'.
+An array of numerical values each in a range of 1-6 denoting the depths of headings that should participate in term-based link creation ("linkification"). Note the dependency on `indexing.headingDepths`: The latter controls which headings to index as "terms" *at all* so only indexed headings can be linkified at all. As you likely guess this means that configuring `indexing.headingDepths: [1]` but `linking.headingDepths:[1,2]` would *not* linkify term headings at depth `2` because they haven't been indexed, before. Instead with `indexing.headingDepths: [1,2,3]` *they would* because then headings at depth 1 to 3 would be indexed which includes headings at depth `2`, of course. Or long story short: `linking.headingDepths` is expected to be a fully enclosed subset of `indexing.headingDepths`.
 
 `headingDepths`
 

--- a/conf/v5/doc/schema-properties-glossaries-items.md
+++ b/conf/v5/doc/schema-properties-glossaries-items.md
@@ -63,7 +63,7 @@ If present, sort terms in output glossary. Default: None. See also i18n options.
 
 ## showUris
 
-Whether to render a term's URI in the glossary (currently for imported glossaries, only).
+Whether to render a term's URI in the glossary (currently for imported glossaries, only). May be a markdown snippet using a placeholder `${uri}` to control URI formatting.
 
 `showUris`
 

--- a/conf/v5/doc/schema-properties-indexing.md
+++ b/conf/v5/doc/schema-properties-indexing.md
@@ -38,8 +38,7 @@ Level of detail by which to group occurrences of terms or syntactic elements in 
 
 ## headingDepths
 
-An array with items in a range of 1-6 denoting the depths of headings that should be indexed. Excluding some headings from indexing is mostly a performance optimization, only. You can just remove the option from your config or stick with defaults. Change defaults only if you are sure that you do not want to have cross-document links onto headings at a particular depth, no matter whether the link was created automatically or written manually.
-The relation to 'linking.headingDepths' is that *this* is about "knowing the link targets" whereas the other is about "creating links" ...based on knowledge about link targets. Yet, indexing of headings is further required for existing (cross-)links like `[foo](#heading-id)` and resolving the path to where a heading with such id was declared, so for example `[foo](../document.md#heading-id)`.
+An array with items in a range of 1-6 denoting the depths of headings that should be indexed for cross-linking. Excluding headings from indexing is mostly a performance optimization, applicable when only headings at a particular depth should participate in id-based cross-linking or term-based auto linking. Note that it is possible to keep indexing all headings to support manually written id-based cross-links for all headings but restricting auto-linking to a subset of headings at a particular depth using `linking.headingDepths` (see `linking` options).
 
 `headingDepths`
 

--- a/conf/v5/doc/schema-properties-linking.md
+++ b/conf/v5/doc/schema-properties-linking.md
@@ -100,7 +100,7 @@ Control the link density and whether every occurrence of a term in your document
 
 ## headingDepths
 
-An array of numerical values each in a range of 1-6 denoting the depths of headings that should participate in term-based link creation ("linkification"). In case you have modified 'indexing.headingDepths', be aware that 'linking.headingDepths' makes only sense if it is a full subset of the items in 'indexing.headingDepths'.
+An array of numerical values each in a range of 1-6 denoting the depths of headings that should participate in term-based link creation ("linkification"). Note the dependency on `indexing.headingDepths`: The latter controls which headings to index as "terms" *at all* so only indexed headings can be linkified at all. As you likely guess this means that configuring `indexing.headingDepths: [1]` but `linking.headingDepths:[1,2]` would *not* linkify term headings at depth `2` because they haven't been indexed, before. Instead with `indexing.headingDepths: [1,2,3]` *they would* because then headings at depth 1 to 3 would be indexed which includes headings at depth `2`, of course. Or long story short: `linking.headingDepths` is expected to be a fully enclosed subset of `indexing.headingDepths`.
 
 `headingDepths`
 

--- a/conf/v5/doc/schema.md
+++ b/conf/v5/doc/schema.md
@@ -447,7 +447,7 @@ If present, sort terms in output glossary. Default: None. See also i18n options.
 
 ### showUris
 
-Whether to render a term's URI in the glossary (currently for imported glossaries, only).
+Whether to render a term's URI in the glossary (currently for imported glossaries, only). May be a markdown snippet using a placeholder `${uri}` to control URI formatting.
 
 `showUris`
 
@@ -529,6 +529,16 @@ The JSON file to import terms from.
 
 *   Type: `string`
 
+### context
+
+File path or URL to a custom JSON-LD context document. Expected to map attributes and type names of a custom import document format onto terms of the well-known W3C SKOS vocabulary.
+
+`context`
+
+*   is optional
+
+*   Type: `string`
+
 ## Definitions group indexFile
 
 Reference this group by using
@@ -545,17 +555,7 @@ Path relative to 'outDir' where to create the index markdown file.
 
 `file`
 
-*   is optional
-
-*   Type: `string`
-
-### class
-
-The class is used to compile lists of content elements. Elements with a common class will be compiled into the same list.
-
-`class`
-
-*   is optional
+*   is required
 
 *   Type: `string`
 
@@ -571,13 +571,23 @@ The page title for the index file. If missing the application uses a default val
 
 ### glossary
 
-Path to a particular glossary file with terms to restrict the index document to. Only affects Index generation with 'indexFiles' property. Since v5.1.0.
+When you configured multiple glossaries, then this option can be used to generate an index file with terms of a particular glossary, only. Use with `generateFiles.indexFiles` (not `generateFiles.indexFile`). Since v5.1.0.
 
 `glossary`
 
 *   is optional
 
 *   Type: `string`
+
+### hideDeepLinks
+
+When this is `false` (default) then term occurrences in sections deeper than `indexing.groupByHeadingDepth` will be represented as short numeric links attached to a parent heading at depth `indexing.groupByHeadingDepth`. With this option being `true` you can disable these "deep" section links. Note that index file generation also depends on the kind of headings being indexed *at all* (see `indexing.headingDepths`). Since v6.1.0.
+
+`hideDeepLinks`
+
+*   is optional
+
+*   Type: `boolean`
 
 ## Definitions group indexing
 
@@ -607,8 +617,7 @@ Level of detail by which to group occurrences of terms or syntactic elements in 
 
 ### headingDepths
 
-An array with items in a range of 1-6 denoting the depths of headings that should be indexed. Excluding some headings from indexing is mostly a performance optimization, only. You can just remove the option from your config or stick with defaults. Change defaults only if you are sure that you do not want to have cross-document links onto headings at a particular depth, no matter whether the link was created automatically or written manually.
-The relation to 'linking.headingDepths' is that *this* is about "knowing the link targets" whereas the other is about "creating links" ...based on knowledge about link targets. Yet, indexing of headings is further required for existing (cross-)links like `[foo](#heading-id)` and resolving the path to where a heading with such id was declared, so for example `[foo](../document.md#heading-id)`.
+An array with items in a range of 1-6 denoting the depths of headings that should be indexed for cross-linking. Excluding headings from indexing is mostly a performance optimization, applicable when only headings at a particular depth should participate in id-based cross-linking or term-based auto linking. Note that it is possible to keep indexing all headings to support manually written id-based cross-links for all headings but restricting auto-linking to a subset of headings at a particular depth using `linking.headingDepths` (see `linking` options).
 
 `headingDepths`
 
@@ -864,7 +873,7 @@ Control the link density and whether every occurrence of a term in your document
 
 ### headingDepths
 
-An array of numerical values each in a range of 1-6 denoting the depths of headings that should participate in term-based link creation ("linkification"). In case you have modified 'indexing.headingDepths', be aware that 'linking.headingDepths' makes only sense if it is a full subset of the items in 'indexing.headingDepths'.
+An array of numerical values each in a range of 1-6 denoting the depths of headings that should participate in term-based link creation ("linkification"). Note the dependency on `indexing.headingDepths`: The latter controls which headings to index as "terms" *at all* so only indexed headings can be linkified at all. As you likely guess this means that configuring `indexing.headingDepths: [1]` but `linking.headingDepths:[1,2]` would *not* linkify term headings at depth `2` because they haven't been indexed, before. Instead with `indexing.headingDepths: [1,2,3]` *they would* because then headings at depth 1 to 3 would be indexed which includes headings at depth `2`, of course. Or long story short: `linking.headingDepths` is expected to be a fully enclosed subset of `indexing.headingDepths`.
 
 `headingDepths`
 

--- a/conf/v5/schema.json
+++ b/conf/v5/schema.json
@@ -260,7 +260,7 @@
                     ,"type": "string"
                 }
                 ,"hideDeepLinks": {
-                    "description": "Term occurrences in sections *deeper than* `indexing.groupByHeadingDepth` will be represented as short numeric links attached to a parent heading at depth `indexing.groupByHeadingDepth`. With this option you can disable these \"deep\" section links. This will reduce the \"precision\" by which users can navigate from the Book Index to a particular occurrence of a term in the book. Note that index file rendering also depends on which kind of headings are being indexed *at all* (see `indexing.headingDepths`). Since v6.1.0."
+                    "description": "When this is `false` (default) then term occurrences in sections deeper than `indexing.groupByHeadingDepth` will be represented as short numeric links attached to a parent heading at depth `indexing.groupByHeadingDepth`. With this option being `true` you can disable these \"deep\" section links. Note that index file generation also depends on the kind of headings being indexed *at all* (see `indexing.headingDepths`). Since v6.1.0."
                     ,"type": "boolean"
                 }
             }

--- a/conf/v5/schema.json
+++ b/conf/v5/schema.json
@@ -256,8 +256,12 @@
                     ,"type": "string"
                 }
                 ,"glossary": {
-                    "description": "Path to a particular glossary file with terms to restrict the index document to. Only affects Index generation with 'indexFiles' property. Since v5.1.0."
+                    "description": "When you configured multiple glossaries, then this option can be used to generate an index file with terms of a particular glossary, only. Use with `generateFiles.indexFiles` (not `generateFiles.indexFile`). Since v5.1.0."
                     ,"type": "string"
+                }
+                ,"hideDeepLinks": {
+                    "description": "Term occurrences in sections *deeper than* `indexing.groupByHeadingDepth` will be represented as short numeric links attached to a parent heading at depth `indexing.groupByHeadingDepth`. With this option you can disable these \"deep\" section links. This will reduce the \"precision\" by which users can navigate from the Book Index to a particular occurrence of a term in the book. Note that index file rendering also depends on which kind of headings are being indexed *at all* (see `indexing.headingDepths`). Since v6.1.0."
+                    ,"type": "boolean"
                 }
             }
         }
@@ -271,7 +275,7 @@
                     ,"maximum": 6
                 }
                 ,"headingDepths": {
-                    "description": "An array with items in a range of 1-6 denoting the depths of headings that should be indexed. Excluding some headings from indexing is mostly a performance optimization, only. You can just remove the option from your config or stick with defaults. Change defaults only if you are sure that you do not want to have cross-document links onto headings at a particular depth, no matter whether the link was created automatically or written manually.\nThe relation to 'linking.headingDepths' is that _this_ is about \"knowing the link targets\" whereas the other is about \"creating links\" ...based on knowledge about link targets. Yet, indexing of headings is further required for existing (cross-)links like `[foo](#heading-id)` and resolving the path to where a heading with such id was declared, so for example `[foo](../document.md#heading-id)`."
+                    "description": "An array with items in a range of 1-6 denoting the depths of headings that should be indexed for cross-linking. Excluding headings from indexing is mostly a performance optimization, applicable when only headings at a particular depth should participate in id-based cross-linking or term-based auto linking. Note that it is possible to keep indexing all headings to support manually written id-based cross-links for all headings but restricting auto-linking to a subset of headings at a particular depth using `linking.headingDepths` (see `linking` options)."
                     ,"type": "array"
                     ,"items": {
                         "type": "integer"
@@ -368,7 +372,7 @@
                     ,"enum": ["all", "first-in-paragraph"]
                 }
                 ,"headingDepths": {
-                    "description": "An array of numerical values each in a range of 1-6 denoting the depths of headings that should participate in term-based link creation (\"linkification\"). In case you have modified 'indexing.headingDepths', be aware that 'linking.headingDepths' makes only sense if it is a full subset of the items in 'indexing.headingDepths'."
+                    "description": "An array of numerical values each in a range of 1-6 denoting the depths of headings that should participate in term-based link creation (\"linkification\"). Note the dependency on `indexing.headingDepths`: The latter controls which headings to index as \"terms\" *at all* so only indexed headings can be linkified at all. As you likely guess this means that configuring `indexing.headingDepths: [1]` but `linking.headingDepths:[1,2]` would *not* linkify term headings at depth `2` because they haven't been indexed, before. Instead with `indexing.headingDepths: [1,2,3]` *they would* because then headings at depth 1 to 3 would be indexed which includes headings at depth `2`, of course. Or long story short: `linking.headingDepths` is expected to be a fully enclosed subset of `indexing.headingDepths`."
                     ,"type": "array"
                     ,"items": {
                         "type": "integer"

--- a/conf/v5/schema.json
+++ b/conf/v5/schema.json
@@ -189,10 +189,10 @@
                     ,"enum": ["asc", "desc"]
                 }
                 ,"showUris": {
-                    "description": "Whether to render a term's URI in the glossary (currently for imported glossaries, only)."
+                    "description": "Whether to render a term's URI in the glossary (currently for imported glossaries, only). May be a markdown snippet using a placeholder `${uri}` to control URI formatting."
                     ,"oneOf": [
-                        { "type": "boolean"}
-                        ,{ "type": "string" }
+                        { "type": "boolean", "description": "`true` or `false`"}
+                        ,{ "type": "string", "description": "Can be a Markdown snippet using a placeholder `${uri}`." }
                     ]
                     ,"since": "6.0.0"
                 }
@@ -237,6 +237,10 @@
                     ,"type": "string"
                     ,"default": ""
                 }
+                ,"context": {
+                    "description": "File path or URL to a custom JSON-LD context document. Expected to map attributes and type names of a custom import document format onto terms of the well-known W3C SKOS vocabulary."
+                    ,"type": "string"
+                }
             }
             ,"required": ["file"]
         }
@@ -245,10 +249,6 @@
             ,"properties": {
                 "file":  {
                     "description": "Path relative to 'outDir' where to create the index markdown file."
-                    ,"type": "string"
-                }
-                ,"class": {
-                    "description": "The class is used to compile lists of content elements. Elements with a common class will be compiled into the same list."
                     ,"type": "string"
                 }
                 ,"title": {
@@ -264,6 +264,7 @@
                     ,"type": "boolean"
                 }
             }
+            ,"required": ["file"]
         }
         ,"indexing": {
             "type": "object"

--- a/lib/index/terms.js
+++ b/lib/index/terms.js
@@ -73,8 +73,8 @@ export function getAST(context, indexFileConf) {
             ,hideDeepLinks: false
         }
         ,indexFileConf || {}
-        );
-        if (indexFileConf.glossary) {
+    );
+    if (indexFileConf.glossary) {
         indexEntries = {};
         const baseDir = context.conf.baseDir;
         const glossaryFile = relativeFromTo(baseDir, glossary, baseDir);

--- a/lib/index/terms.js
+++ b/lib/index/terms.js
@@ -1,4 +1,4 @@
-import { heading, html, link, paragraph, root, text } from "mdast-builder";
+import { heading, html, link, paragraph, root, strong, text } from "mdast-builder";
 import { getNodeId, getNodeText } from "../ast/tools.js";
 import { TermDefinitionNode } from "../ast/with/term-definition.js";
 import { TermOccurrenceNode } from "../ast/with/term-occurrence.js";
@@ -67,10 +67,17 @@ export const indexes = [{
  */
 export function getAST(context, indexFileConf) {
     let indexEntries;
-    if (indexFileConf.glossary) {
+    const { title, glossary } = indexFileConf = Object.assign(
+        {
+            title: "Book Index"
+            ,hideDeepLinks: false
+        }
+        ,indexFileConf || {}
+        );
+        if (indexFileConf.glossary) {
         indexEntries = {};
         const baseDir = context.conf.baseDir;
-        const glossaryFile = relativeFromTo(baseDir, indexFileConf.glossary, baseDir);
+        const glossaryFile = relativeFromTo(baseDir, glossary, baseDir);
         const termsEntries = getIndex(IDX_TERMS);
         const termOccEntries = getIndex(IDX_OCCURRENCES_BY_PHRASE);
         (termsEntries[0] || [])
@@ -86,15 +93,6 @@ export function getAST(context, indexFileConf) {
         indexEntries = getIndex(IDX_OCCURRENCES_BY_PHRASE);
     }
 
-    const indexFile = indexFileConf.file;
-    let title = "";
-    if (indexFileConf !== null && typeof indexFileConf === "object") {
-        title = indexFileConf.title;
-    }
-    if (!title) {
-        title = "Book Index";
-    }
-
     // Create AST from index
     let tree = [
         heading(1, text(title))
@@ -102,7 +100,7 @@ export function getAST(context, indexFileConf) {
         ,...Object
             .keys(indexEntries)
             .sort((key1, key2) => collator.compare(key1, key2))
-            .map((key) => getIndexEntryAst(context, indexEntries[key], indexFile))
+            .map((key) => getIndexEntryAst(context, indexEntries[key], indexFileConf))
     ];
     return root(tree);
 }
@@ -111,16 +109,16 @@ export function getAST(context, indexFileConf) {
  *
  * @param {Context} context
  * @param {IndexEntry} entriesForKey
- * @param {string} indexFilename
+ * @param {Object} indexFileConf
  * @returns {Node} mdast tree
  */
-function getIndexEntryAst(context, entriesForKey, indexFile) {
+function getIndexEntryAst(context, entriesForKey, indexFileConf) {
     const key = getNodeText(entriesForKey[0].node);
     return paragraph([
         heading(2, text(key))
         ,brk
         ,brk
-        ,...getEntryLinksAst(context, entriesForKey, indexFile)
+        ,...getEntryLinksAst(context, entriesForKey, indexFileConf)
     ]);
 }
 
@@ -128,13 +126,13 @@ function getIndexEntryAst(context, entriesForKey, indexFile) {
  *
  * @param {Context} context
  * @param {IndexEntry} indexEntry
- * @param {string} indexFile
+ * @param {Object} indexFileConf
  */
-function getEntryLinksAst(context, entriesForKey, indexFile) {
+function getEntryLinksAst(context, entriesForKey, indexFileConf) {
     const byHeadings = group(entriesForKey, byGroupHeading);
     const links = [
-        ...getGlossaryLinksAst(context, entriesForKey, indexFile)
-        ,...getDocumentLinksAst(context, byHeadings, indexFile)
+        ...getGlossaryLinksAst(context, entriesForKey, indexFileConf)
+        ,...getDocumentLinksAst(context, byHeadings, indexFileConf)
     ];
     const linksSeparated = [];
     for (let i = 0, len = links.length; i < len; i++) {
@@ -152,7 +150,8 @@ function getEntryLinksAst(context, entriesForKey, indexFile) {
  * @param {string} fromIndexFilename
  * @returns {Node} mdast Node
  */
-function getGlossaryLinksAst(context, entriesForKey, fromIndexFilename) {
+function getGlossaryLinksAst(context, entriesForKey, indexFileConf) {
+    const fromIndexFilename = indexFileConf.file;
     return entriesForKey[0].node.termDefs
         .sort(TermDefinitionNode.compare)
         .map((termDefinitionNode) => {
@@ -167,37 +166,53 @@ function getGlossaryLinksAst(context, entriesForKey, fromIndexFilename) {
  * @param {IndexEntry} indexEntry
  * @returns {Node} mdast tree
  */
-function getDocumentLinksAst(context, byHeadings, fromIndexFilename) {
+function getDocumentLinksAst(context, byHeadings, indexFileConf) {
     return byHeadings
         .map((indexEntryOccurrences) => {
             const indexEntry = indexEntryOccurrences[0]; // [1]
-            const headingNode = indexEntry.groupHeadingNode;
             const toDocumentFilename = indexEntry.file;
-            const sectionId = getNodeId(headingNode);
+            const fromIndexFilename = indexFileConf.file;
+            const hideDeepLinks = indexFileConf.hideDeepLinks;
             const termNode = indexEntry.node.termDefs[0];
-            const ref = getFileLinkUrl(context, fromIndexFilename, toDocumentFilename, sectionId);
-            let linkText;
-            if (headingNode) {
-                linkText = getNodeText(headingNode);
+            const targetHeadingNode = indexEntry.groupHeadingNode;
+            const targetHeadingId = getNodeId(targetHeadingNode);
+            const targetUrl = getFileLinkUrl(context, fromIndexFilename, toDocumentFilename, targetHeadingId);
+            const groupByHeadingDepth = context.conf.indexing.groupByHeadingDepth;
+            let linkLabel;
+            let linkLabelNode;
+
+            if (targetHeadingNode) {
+                linkLabel = getNodeText(targetHeadingNode);
             } else {
-                linkText = ref;
+                linkLabel = targetUrl;
             }
-            if (linkText === termNode.glossVFile.glossConf.title) {
+            if (linkLabel === termNode.glossVFile.glossConf.title) {
                 // prevent duplicate listing of glossary title (see also getGlossaryLinksAst())
                 return null;
             } else {
-                const deepOccurrencesAst = getLinksToOccurrenceAst(context, fromIndexFilename, indexEntryOccurrences);
-                let linkNode = text(linkText);
-                if (deepOccurrencesAst.length === 0) {
-                    return link(ref, null, linkNode);
-                } else {
-                    return paragraph([
-                        link(ref, null, linkNode)
-                        ,html("<sub>↳ ")
-                        ,...deepOccurrencesAst
-                        ,html("</sub>")
-                    ]);
-                }
+                linkLabelNode = text(linkLabel);
+            }
+
+            if (targetHeadingNode
+                && targetHeadingNode.depth === 1
+                && groupByHeadingDepth > 1
+            ) {
+                // If a Book Index not only contains links to pages but also
+                // links to page sections, then among all links highlight those
+                // pointing to a page.
+                linkLabelNode = strong([linkLabelNode]);
+            }
+
+            const deepOccurrencesAst = getLinksToOccurrenceAst(context, fromIndexFilename, indexEntryOccurrences);
+            if (hideDeepLinks || deepOccurrencesAst.length === 0) {
+                return link(targetUrl, null, linkLabelNode);
+            } else {
+                return paragraph([
+                    link(targetUrl, null, linkLabelNode)
+                    ,html("<sub>↳ ")
+                    ,...deepOccurrencesAst
+                    ,html("</sub>")
+                ]);
             }
         })
         .filter(linkNode => linkNode !== null);

--- a/md/README.md
+++ b/md/README.md
@@ -794,21 +794,27 @@ Paths or Glob-Patterns of files to exclude. Excluded files will be excluded from
 
 #### `generateFiles.indexFile`
 
-- **Range:** `{file: string, [title: string]}`
+[doc-config-indexFile]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-generatefiles-properties-indexfile.md
+
+- **Range:** `{file: string, [title: string], [hideDeepLinks: boolean]}` ([details][doc-config-indexFile])
 - **Since:** v3.0.0
 
 Generates an index of glossary terms with links to files in which they have been mentioned.
 
 #### `generateFiles.indexFiles`
 
-- **Range:** `Array<{file: string, glossary: string, [title: string]}>`
+[doc-config-indexFiles]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-generatefiles-properties-indexfiles-items.md
+
+- **Range:** `Array<{file: string, glossary: string, [title: string], [hideDeepLinks: boolean]}>` ([details][doc-config-indexFiles])
 - **Since:** v3.0.0
 
-Similar to `indexFile` but allows for generating an index per glossary.
+Similar to `indexFile` but allows for generating multiple index files, e.g. one per glossary.
 
 #### `generateFiles.listOf`
 
-- **Range:** `Array<{class: string, file: string, [title: string]}>`
+[doc-config-listOf]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-generatefiles-properties-listof-items.md
+
+- **Range:** `Array<{class: string, file: string, [title: string]}>` ([details][doc-config-listof])
 - **Since:** v3.5.0
 
 If available, generates a list from HTML anchors exposing the configured `class` attribute.
@@ -855,17 +861,21 @@ sequence. If you would like to have the glossary sorted provide a *sort* directi
 
 #### `glossaries[].export`
 
-- **Range:** `{ file: string [, context: string]} | Array<{ file: string [, context: string]}>`
+[doc-config-exports]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-glossaryfile-properties-export-oneof-0.md
+
+- **Range:** `{ file: string [, context: string]} | Array<{ file: string [, context: string]}>` ([details][doc-config-export])
 - **Since:** v6.0.0
 
 Export markdown terms in a structured JSON format. More read [here][doc-export-import].
 
 #### `glossaries[].import`
 
-- **Range:** `{ file: string [, context: string]}`
+[doc-config-import]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-glossaryfile-properties-import.md
+
+- **Range:** `{ file: string [, context: string]}` ([details][doc-config-import])
 - **Since:** v6.0.0
 
-Import terms from a structured JSON format and generate a markdown glossary from it. More read [here][doc-export-import].
+Import terms from a structured JSON format and generate a markdown glossary from it. For an example see [here][doc-export-import].
 
 #### `glossaries[].linkUris`
 

--- a/md/README.md
+++ b/md/README.md
@@ -861,7 +861,7 @@ sequence. If you would like to have the glossary sorted provide a *sort* directi
 
 #### `glossaries[].export`
 
-[doc-config-exports]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-glossaryfile-properties-export-oneof-0.md
+[doc-config-export]: https://github.com/about-code/glossarify-md/blob/master/conf/v5/doc/schema-defs-glossaryfile-properties-export-oneof-0.md
 
 - **Range:** `{ file: string [, context: string]} | Array<{ file: string [, context: string]}>` ([details][doc-config-export])
 - **Since:** v6.0.0

--- a/test/input/config-indexFiles/hideDeepLinks/document.md
+++ b/test/input/config-indexFiles/hideDeepLinks/document.md
@@ -1,0 +1,86 @@
+# Title Depth 1
+
+GIVEN
+
+- a configuration
+
+  ~~~json
+  {
+    "glossaries": [
+      { "file": "./glossary-1.md" },
+      { "file": "./glossary-2.md" },
+      { "file": "./glossary-3.md" }
+    ],
+    "indexing": {
+      "groupByHeadingDepth": 2
+    },
+    "generateFiles": {
+      "indexFiles": [{
+        "file": "./index-1-hide-true.md",
+        "glossary": "./glossary-1.md",
+        "hideDeepLinks": true
+      },{
+        "file": "./index-2-hide-false.md",
+        "glossary": "./glossary-2.md",
+        "hideDeepLinks": false
+      },{
+        "file": "./index-3-hide-default.md",
+        "glossary": "./glossary-3.md"
+      }]
+    }
+  }
+  ~~~
+
+- AND three glossaries
+  - `glossary-1.md` WITH term *Term1*
+  - `glossary-2.md` WITH term *Term2*
+  - `glossary-3.md` WITH term *Term3*
+- AND these terms being mentioned in *this* file
+  - AND in *this section* at depth 1
+  - AND in *sections below* being sections at depths 2 to 6
+- AND `indexing.groupByHeadingDepth: 2`
+
+THEN
+
+- three index files must be generated
+  - AND `./index-1-hide-true.md`
+    - MUST have a single entry *Term1*
+    - AND there MUST be links to sections
+      - Glossary 1
+      - Title Depth 1
+      - Section Depth 2
+  - AND `./index-2-hide-false.md`
+    - MUST have a single entry *Term2*
+    - AND there MUST be links
+      - WITH label *Glossary 1* linking to document section *Glossary 1*
+      - WITH label *Title Depth 1* linking to document section *Title Depth 1*
+      - WITH label *Section Depth 2* linking to document section *Section Depth 2*
+        - WITH label *2* linking to document section *Section Depth 3*
+        - WITH label *3* linking to document section *Section Depth 4*
+        - WITH label *4* linking to document section *Section Depth 5*
+        - WITH label *5* linking to document section *Section Depth 6*
+  - AND `./index-3-hide-default.md`
+     - MUST have a single entry *Term3*
+     - AND MUST otherwise generate links identical to `./index-2-hide-false.md`
+       because the default is expected to be `hideDeepLinks: false`.
+
+
+## Section Depth 2
+
+Term1, Term2, Term3.
+
+### Section Depth 3
+
+Term1, Term2, Term3.
+
+#### Section Depth 4
+
+Term1, Term2, Term3.
+
+##### Section Depth 5
+
+Term1, Term2, Term3.
+
+###### Section Depth 6
+
+Term1, Term2, Term3.

--- a/test/input/config-indexFiles/hideDeepLinks/glossarify-md.conf.json
+++ b/test/input/config-indexFiles/hideDeepLinks/glossarify-md.conf.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../../conf/v5/schema.json",
+  "baseDir": ".",
+  "outDir": "../../../output-actual/config-indexFiles/hideDeepLinks",
+  "glossaries": [
+    { "file": "./glossary-1.md" },
+    { "file": "./glossary-2.md" },
+    { "file": "./glossary-3.md" }
+  ],
+  "indexing": {
+    "groupByHeadingDepth": 2
+  },
+  "generateFiles": {
+    "indexFiles": [{
+      "file": "./index-1-hide-true.md",
+      "glossary": "./glossary-1.md",
+      "hideDeepLinks": true
+    },{
+      "file": "./index-2-hide-false.md",
+      "glossary": "./glossary-2.md",
+      "hideDeepLinks": false
+    },{
+      "file": "./index-3-hide-default.md",
+      "glossary": "./glossary-3.md"
+    }]
+  }
+}

--- a/test/input/config-indexFiles/hideDeepLinks/glossary-1.md
+++ b/test/input/config-indexFiles/hideDeepLinks/glossary-1.md
@@ -1,0 +1,5 @@
+# Glossary 1
+
+## Term1
+
+Term 1.

--- a/test/input/config-indexFiles/hideDeepLinks/glossary-2.md
+++ b/test/input/config-indexFiles/hideDeepLinks/glossary-2.md
@@ -1,0 +1,5 @@
+# Glossary 2
+
+## Term2
+
+Term 2.

--- a/test/input/config-indexFiles/hideDeepLinks/glossary-3.md
+++ b/test/input/config-indexFiles/hideDeepLinks/glossary-3.md
@@ -1,0 +1,5 @@
+# Glossary 3
+
+## Term3
+
+Term 3.

--- a/test/output-expected/config-glossaries/file-glob-and-index/index/generated.md
+++ b/test/output-expected/config-glossaries/file-glob-and-index/index/generated.md
@@ -2,7 +2,7 @@
 
 ## [Second Level\~](#second-level)
 
-[Glossary 2][1] ○ [Testing Index generation for glossaries file glob][2]
+[Glossary 2][1] ○ [**Testing Index generation for glossaries file glob**][2]
 
 ## [Third Level\~](#third-level)
 

--- a/test/output-expected/config-indexFiles/154-deep-dir/index-a.md
+++ b/test/output-expected/config-indexFiles/154-deep-dir/index-a.md
@@ -2,15 +2,15 @@
 
 ## [GlossaryA\_Term1](#glossarya_term1)
 
-[Glossary A][1] ○ [Testing config indexFiles with multiple index files][2]
+[Glossary A][1] ○ [**Testing config indexFiles with multiple index files**][2]
 
 ## [GlossaryA\_Term2](#glossarya_term2)
 
-[Glossary A][3] ○ [Testing config indexFiles with multiple index files][2]
+[Glossary A][3] ○ [**Testing config indexFiles with multiple index files**][2]
 
 ## [GlossaryABC\_Term3](#glossaryabc_term3)
 
-[Glossary A][4] ○ [Glossary B][5] ○ [Glossary C][6] ○ [Testing config indexFiles with multiple index files][2]
+[Glossary A][4] ○ [Glossary B][5] ○ [Glossary C][6] ○ [**Testing config indexFiles with multiple index files**][2]
 
 [1]: ./glossary-a.md#glossarya_term1
 

--- a/test/output-expected/config-indexFiles/154-deep-dir/sub1-index/index-b.md
+++ b/test/output-expected/config-indexFiles/154-deep-dir/sub1-index/index-b.md
@@ -2,15 +2,15 @@
 
 ## [GlossaryABC\_Term3](#glossaryabc_term3)
 
-[Glossary A][1] ○ [Glossary B][2] ○ [Glossary C][3] ○ [Testing config indexFiles with multiple index files][4]
+[Glossary A][1] ○ [Glossary B][2] ○ [Glossary C][3] ○ [**Testing config indexFiles with multiple index files**][4]
 
 ## [GlossaryB\_Term1](#glossaryb_term1)
 
-[Glossary B][5] ○ [Testing config indexFiles with multiple index files][4]
+[Glossary B][5] ○ [**Testing config indexFiles with multiple index files**][4]
 
 ## [GlossaryB\_Term2](#glossaryb_term2)
 
-[Glossary B][6] ○ [Testing config indexFiles with multiple index files][4]
+[Glossary B][6] ○ [**Testing config indexFiles with multiple index files**][4]
 
 [1]: ../glossary-a.md#glossaryabc_term3
 

--- a/test/output-expected/config-indexFiles/154-deep-dir/sub1-index/sub2-index/index-c.md
+++ b/test/output-expected/config-indexFiles/154-deep-dir/sub1-index/sub2-index/index-c.md
@@ -2,15 +2,15 @@
 
 ## [GlossaryABC\_Term3](#glossaryabc_term3)
 
-[Glossary A][1] ○ [Glossary B][2] ○ [Glossary C][3] ○ [Testing config indexFiles with multiple index files][4]
+[Glossary A][1] ○ [Glossary B][2] ○ [Glossary C][3] ○ [**Testing config indexFiles with multiple index files**][4]
 
 ## [GlossaryC\_Term1](#glossaryc_term1)
 
-[Glossary C][5] ○ [Testing config indexFiles with multiple index files][4]
+[Glossary C][5] ○ [**Testing config indexFiles with multiple index files**][4]
 
 ## [GlossaryC\_Term2](#glossaryc_term2)
 
-[Glossary C][6] ○ [Testing config indexFiles with multiple index files][4]
+[Glossary C][6] ○ [**Testing config indexFiles with multiple index files**][4]
 
 [1]: ../../glossary-a.md#glossaryabc_term3
 

--- a/test/output-expected/config-indexFiles/flat-dir/index-a.md
+++ b/test/output-expected/config-indexFiles/flat-dir/index-a.md
@@ -2,15 +2,15 @@
 
 ## [GlossaryA\_Term1](#glossarya_term1)
 
-[Glossary A][1] ○ [Testing config indexFiles with multiple index files][2]
+[Glossary A][1] ○ [**Testing config indexFiles with multiple index files**][2]
 
 ## [GlossaryA\_Term2](#glossarya_term2)
 
-[Glossary A][3] ○ [Testing config indexFiles with multiple index files][2]
+[Glossary A][3] ○ [**Testing config indexFiles with multiple index files**][2]
 
 ## [GlossaryAB\_Term3](#glossaryab_term3)
 
-[Glossary A][4] ○ [Glossary B][5] ○ [Testing config indexFiles with multiple index files][2]
+[Glossary A][4] ○ [Glossary B][5] ○ [**Testing config indexFiles with multiple index files**][2]
 
 [1]: ./glossary-a.md#glossarya_term1
 

--- a/test/output-expected/config-indexFiles/flat-dir/index-b.md
+++ b/test/output-expected/config-indexFiles/flat-dir/index-b.md
@@ -2,15 +2,15 @@
 
 ## [GlossaryAB\_Term3](#glossaryab_term3)
 
-[Glossary A][1] ○ [Glossary B][2] ○ [Testing config indexFiles with multiple index files][3]
+[Glossary A][1] ○ [Glossary B][2] ○ [**Testing config indexFiles with multiple index files**][3]
 
 ## [GlossaryB\_Term1](#glossaryb_term1)
 
-[Glossary B][4] ○ [Testing config indexFiles with multiple index files][3]
+[Glossary B][4] ○ [**Testing config indexFiles with multiple index files**][3]
 
 ## [GlossaryB\_Term2](#glossaryb_term2)
 
-[Glossary B][5] ○ [Testing config indexFiles with multiple index files][3]
+[Glossary B][5] ○ [**Testing config indexFiles with multiple index files**][3]
 
 [1]: ./glossary-a.md#glossaryab_term3
 

--- a/test/output-expected/config-indexFiles/hideDeepLinks/document.md
+++ b/test/output-expected/config-indexFiles/hideDeepLinks/document.md
@@ -1,0 +1,93 @@
+# [Title Depth 1](#title-depth-1)
+
+GIVEN
+
+*   a configuration
+
+    ```json
+    {
+      "glossaries": [
+        { "file": "./glossary-1.md" },
+        { "file": "./glossary-2.md" },
+        { "file": "./glossary-3.md" }
+      ],
+      "indexing": {
+        "groupByHeadingDepth": 2
+      },
+      "generateFiles": {
+        "indexFiles": [{
+          "file": "./index-1-hide-true.md",
+          "glossary": "./glossary-1.md",
+          "hideDeepLinks": true
+        },{
+          "file": "./index-2-hide-false.md",
+          "glossary": "./glossary-2.md",
+          "hideDeepLinks": false
+        },{
+          "file": "./index-3-hide-default.md",
+          "glossary": "./glossary-3.md"
+        }]
+      }
+    }
+    ```
+
+*   AND three glossaries
+    *   `glossary-1.md` WITH term *[Term1][1]*
+    *   `glossary-2.md` WITH term *[Term2][2]*
+    *   `glossary-3.md` WITH term *[Term3][3]*
+
+*   AND these terms being mentioned in *this* file
+    *   AND in *this section* at depth 1
+    *   AND in *sections below* being sections at depths 2 to 6
+
+*   AND `indexing.groupByHeadingDepth: 2`
+
+THEN
+
+*   three index files must be generated
+    *   AND `./index-1-hide-true.md`
+        *   MUST have a single entry *[Term1][1]*
+        *   AND there MUST be links to sections
+            *   Glossary 1
+            *   Title Depth 1
+            *   Section Depth 2
+    *   AND `./index-2-hide-false.md`
+        *   MUST have a single entry *[Term2][2]*
+        *   AND there MUST be links
+            *   WITH label *Glossary 1* linking to document section *Glossary 1*
+            *   WITH label *Title Depth 1* linking to document section *Title Depth 1*
+            *   WITH label *Section Depth 2* linking to document section *Section Depth 2*
+                *   WITH label *2* linking to document section *Section Depth 3*
+                *   WITH label *3* linking to document section *Section Depth 4*
+                *   WITH label *4* linking to document section *Section Depth 5*
+                *   WITH label *5* linking to document section *Section Depth 6*
+    *   AND `./index-3-hide-default.md`
+        *   MUST have a single entry *[Term3][3]*
+        *   AND MUST otherwise generate links identical to `./index-2-hide-false.md`
+            because the default is expected to be `hideDeepLinks: false`.
+
+## [Section Depth 2](#section-depth-2)
+
+[Term1][1], [Term2][2], [Term3][3].
+
+### [Section Depth 3](#section-depth-3)
+
+[Term1][1], [Term2][2], [Term3][3].
+
+#### [Section Depth 4](#section-depth-4)
+
+[Term1][1], [Term2][2], [Term3][3].
+
+##### [Section Depth 5](#section-depth-5)
+
+[Term1][1], [Term2][2], [Term3][3].
+
+###### [Section Depth 6](#section-depth-6)
+
+[Term1][1], [Term2][2], [Term3][3].
+
+[1]: ./glossary-1.md#term1 "Term 1."
+
+[2]: ./glossary-2.md#term2 "Term 2."
+
+[3]: ./glossary-3.md#term3 "Term 3."

--- a/test/output-expected/config-indexFiles/hideDeepLinks/glossarify-md.conf.json
+++ b/test/output-expected/config-indexFiles/hideDeepLinks/glossarify-md.conf.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../../conf/v5/schema.json",
+  "baseDir": ".",
+  "outDir": "../../../output-actual/config-indexFiles/hideDeepLinks",
+  "glossaries": [
+    { "file": "./glossary-1.md" },
+    { "file": "./glossary-2.md" },
+    { "file": "./glossary-3.md" }
+  ],
+  "indexing": {
+    "groupByHeadingDepth": 2
+  },
+  "generateFiles": {
+    "indexFiles": [{
+      "file": "./index-1-hide-true.md",
+      "glossary": "./glossary-1.md",
+      "hideDeepLinks": true
+    },{
+      "file": "./index-2-hide-false.md",
+      "glossary": "./glossary-2.md",
+      "hideDeepLinks": false
+    },{
+      "file": "./index-3-hide-default.md",
+      "glossary": "./glossary-3.md"
+    }]
+  }
+}

--- a/test/output-expected/config-indexFiles/hideDeepLinks/glossary-1.md
+++ b/test/output-expected/config-indexFiles/hideDeepLinks/glossary-1.md
@@ -1,0 +1,5 @@
+# [Glossary 1](#glossary-1)
+
+## [Term1](#term1)
+
+Term 1.

--- a/test/output-expected/config-indexFiles/hideDeepLinks/glossary-2.md
+++ b/test/output-expected/config-indexFiles/hideDeepLinks/glossary-2.md
@@ -1,0 +1,5 @@
+# [Glossary 2](#glossary-2)
+
+## [Term2](#term2)
+
+Term 2.

--- a/test/output-expected/config-indexFiles/hideDeepLinks/glossary-3.md
+++ b/test/output-expected/config-indexFiles/hideDeepLinks/glossary-3.md
@@ -1,0 +1,5 @@
+# [Glossary 3](#glossary-3)
+
+## [Term3](#term3)
+
+Term 3.

--- a/test/output-expected/config-indexFiles/hideDeepLinks/index-1-hide-true.md
+++ b/test/output-expected/config-indexFiles/hideDeepLinks/index-1-hide-true.md
@@ -1,0 +1,11 @@
+# [Book Index](#book-index)
+
+## [Term1](#term1)
+
+[Glossary 1][1] ○ [**Title Depth 1**][2] ○ [Section Depth 2][3]
+
+[1]: ./glossary-1.md#term1 "Term 1."
+
+[2]: ./document.md#title-depth-1
+
+[3]: ./document.md#section-depth-2

--- a/test/output-expected/config-indexFiles/hideDeepLinks/index-2-hide-false.md
+++ b/test/output-expected/config-indexFiles/hideDeepLinks/index-2-hide-false.md
@@ -1,0 +1,19 @@
+# [Book Index](#book-index)
+
+## [Term2](#term2)
+
+[Glossary 2][1] ○ [**Title Depth 1**][2] ○ [Section Depth 2][3]<sub>↳ [2][4], [3][5], [4][6], [5][7]</sub>
+
+[1]: ./glossary-2.md#term2 "Term 2."
+
+[2]: ./document.md#title-depth-1
+
+[3]: ./document.md#section-depth-2
+
+[4]: ./document.md#section-depth-3 "Section Depth 3"
+
+[5]: ./document.md#section-depth-4 "Section Depth 4"
+
+[6]: ./document.md#section-depth-5 "Section Depth 5"
+
+[7]: ./document.md#section-depth-6 "Section Depth 6"

--- a/test/output-expected/config-indexFiles/hideDeepLinks/index-3-hide-default.md
+++ b/test/output-expected/config-indexFiles/hideDeepLinks/index-3-hide-default.md
@@ -1,0 +1,19 @@
+# [Book Index](#book-index)
+
+## [Term3](#term3)
+
+[Glossary 3][1] ○ [**Title Depth 1**][2] ○ [Section Depth 2][3]<sub>↳ [2][4], [3][5], [4][6], [5][7]</sub>
+
+[1]: ./glossary-3.md#term3 "Term 3."
+
+[2]: ./document.md#title-depth-1
+
+[3]: ./document.md#section-depth-2
+
+[4]: ./document.md#section-depth-3 "Section Depth 3"
+
+[5]: ./document.md#section-depth-4 "Section Depth 4"
+
+[6]: ./document.md#section-depth-5 "Section Depth 5"
+
+[7]: ./document.md#section-depth-6 "Section Depth 6"

--- a/test/output-expected/config-indexing/groupByHeadingDepth-2-order/index.md
+++ b/test/output-expected/config-indexing/groupByHeadingDepth-2-order/index.md
@@ -2,7 +2,7 @@
 
 ## [Term](#term)
 
-[Glossary][1] ○ [Document 1][2] ○ [Section 1.1][3]<sub>↳ [2][4], [3][5], [4][6], [5][7]</sub> ○ [Section 1.2][8] ○ [Section 1.3][9] ○ [Section 1.4][10] ○ [Document 2][11] ○ [Section 2.1][12]<sub>↳ [2][13], [3][14], [4][15], [5][16]</sub> ○ [Term][17]
+[Glossary][1] ○ [**Document 1**][2] ○ [Section 1.1][3]<sub>↳ [2][4], [3][5], [4][6], [5][7]</sub> ○ [Section 1.2][8] ○ [Section 1.3][9] ○ [Section 1.4][10] ○ [**Document 2**][11] ○ [Section 2.1][12]<sub>↳ [2][13], [3][14], [4][15], [5][16]</sub> ○ [Term][17]
 
 [1]: ./glossary.md#term "GIVEN a term Term AND a config AND two documents document-1.md, document-2.md AND term occurrences in multiple sections of each document AND some term occurrences in sections of a depth less or equal to groupHeadingDepth AND some term occurrences in sections deeper than groupHeadingDepth THEN a file index.md MUST be generated AND the file MUST have a heading Term AND the file MUST group under that heading in this order: Glossary at depth: 1 Document 1 at depth: 1 Section 1.1 at depth: 2 Section 1.1.1 at depth: 3 reduced to label 2 Section 1.1.1.1 at depth: 4 reduced to label 3 Section 1.1.1.1.1 at depth: 5 reduced to label 4 Section 1.1.1.1.1.1 at depth: 6 reduced to label 5 Section 1.2 at depth: 2 Section 1.3 at depth: 2 Section 1.4 at depth: 2 Document 2 at depth: 1 Section 2.1 at depth: 2 Section 2.1.1 at depth: 3 reduced to label 2 Section 2.1.1.1 at depth: 4 reduced to label 3 Section 2.1.1.1.1 at depth: 5 reduced to label 4 Section 2.1.1.1.1.1 at depth: 6 reduced to label 5"
 

--- a/test/output-expected/config-indexing/groupByHeadingDepth-2/index.md
+++ b/test/output-expected/config-indexing/groupByHeadingDepth-2/index.md
@@ -2,7 +2,7 @@
 
 ## [Term1](#term1)
 
-[Glossary][1] ○ [Document][2] ○ [Heading 2 Depth 2][3]<sub>↳ [2][4], [3][5], [4][6]</sub> ○ [Heading 6 Depth 2][7]<sub>↳ [2][8], [3][9], [4][10]</sub> ○ [Term1][11]
+[Glossary][1] ○ [**Document**][2] ○ [Heading 2 Depth 2][3]<sub>↳ [2][4], [3][5], [4][6]</sub> ○ [Heading 6 Depth 2][7]<sub>↳ [2][8], [3][9], [4][10]</sub> ○ [Term1][11]
 
 ## [Term2](#term2)
 

--- a/test/output-expected/config-indexing/groupByHeadingDepth-missing/index.md
+++ b/test/output-expected/config-indexing/groupByHeadingDepth-missing/index.md
@@ -2,7 +2,7 @@
 
 ## [Term1](#term1)
 
-[Glossary][1] ○ [Document][2] ○ [Heading 2 Depth 2][3] ○ [Heading 3 Depth 3][4] ○ [Heading 4 Depth 4][5] ○ [Heading 5 Depth 3][6] ○ [Heading 6 Depth 2][7] ○ [Heading 7 Depth 3][8] ○ [Heading 8 Depth 6][9] ○ [Heading 9 Depth 2][10] ○ [Term1][11]
+[Glossary][1] ○ [**Document**][2] ○ [Heading 2 Depth 2][3] ○ [Heading 3 Depth 3][4] ○ [Heading 4 Depth 4][5] ○ [Heading 5 Depth 3][6] ○ [Heading 6 Depth 2][7] ○ [Heading 7 Depth 3][8] ○ [Heading 8 Depth 6][9] ○ [Heading 9 Depth 2][10] ○ [Term1][11]
 
 ## [Term2](#term2)
 

--- a/test/output-expected/config-linking/headingIdAlgorithm/github/one-glossary-with-same-term-twice/github-index.md
+++ b/test/output-expected/config-linking/headingIdAlgorithm/github/one-glossary-with-same-term-twice/github-index.md
@@ -2,7 +2,7 @@
 
 ## [Alpha](#alpha)
 
-[Glossary 1][1] ○ [Glossary 1][2] ○ [Document 1][3] ○ [Document 2][4]
+[Glossary 1][1] ○ [Glossary 1][2] ○ [**Document 1**][3] ○ [**Document 2**][4]
 
 [1]: ./glossary.md#alpha "First definition."
 

--- a/test/output-expected/config-linking/headingIdAlgorithm/github/two-glossaries-with-same-term/github-index.md
+++ b/test/output-expected/config-linking/headingIdAlgorithm/github/two-glossaries-with-same-term/github-index.md
@@ -2,7 +2,7 @@
 
 ## [Alpha](#alpha)
 
-[Glossary 1][1] ○ [Glossary 2][2] ○ [Document 1][3] ○ [Document 2][4]
+[Glossary 1][1] ○ [Glossary 2][2] ○ [**Document 1**][3] ○ [**Document 2**][4]
 
 [1]: ./glossary-1.md#alpha "First definition."
 

--- a/test/output-expected/config-linking/headingIdAlgorithm/md5/ambiguous-term/md5-index.md
+++ b/test/output-expected/config-linking/headingIdAlgorithm/md5/ambiguous-term/md5-index.md
@@ -2,7 +2,7 @@
 
 ## [Alpha](#md5-b1afca04273052ac654e454590780523)
 
-[Glossary 1][1] ○ [Glossary 2][2] ○ [Document 1][3] ○ [Document 2][4]
+[Glossary 1][1] ○ [Glossary 2][2] ○ [**Document 1**][3] ○ [**Document 2**][4]
 
 [1]: ./glossary-1.md#md5-3e5743fb44c2774df0009ab82b8b8b78 "First definition."
 

--- a/test/output-expected/config-linking/headingIdAlgorithm/sha256-7/one-glossary-with-same-term-twice/sha256-index.md
+++ b/test/output-expected/config-linking/headingIdAlgorithm/sha256-7/one-glossary-with-same-term-twice/sha256-index.md
@@ -2,7 +2,7 @@
 
 ## [Alpha](#sha256-262b27b)
 
-[Glossary 1][1] ○ [Glossary 1][2] ○ [Document 1][3] ○ [Document 2][4]
+[Glossary 1][1] ○ [Glossary 1][2] ○ [**Document 1**][3] ○ [**Document 2**][4]
 
 [1]: ./glossary.md#sha256-d0ae6bd "First definition."
 

--- a/test/output-expected/config-linking/headingIdAlgorithm/sha256-7/two-glossaries-with-same-term-and-uri/sha256-index.md
+++ b/test/output-expected/config-linking/headingIdAlgorithm/sha256-7/two-glossaries-with-same-term-and-uri/sha256-index.md
@@ -2,7 +2,7 @@
 
 ## [Alpha](#sha256-262b27b)
 
-[Glossary 1][1] ○ [Glossary 2][2] ○ [Document 1][3] ○ [Document 2][4]
+[Glossary 1][1] ○ [Glossary 2][2] ○ [**Document 1**][3] ○ [**Document 2**][4]
 
 [1]: ./glossary-1.md#sha256-7e16917 "First definition."
 

--- a/test/output-expected/config-linking/headingIdAlgorithm/sha256-7/two-glossaries-with-same-term/sha256-index.md
+++ b/test/output-expected/config-linking/headingIdAlgorithm/sha256-7/two-glossaries-with-same-term/sha256-index.md
@@ -2,7 +2,7 @@
 
 ## [Alpha](#sha256-262b27b)
 
-[Glossary 1][1] ○ [Glossary 2][2] ○ [Document 1][3] ○ [Document 2][4]
+[Glossary 1][1] ○ [Glossary 2][2] ○ [**Document 1**][3] ○ [**Document 2**][4]
 
 [1]: ./glossary-1.md#sha256-cfbbd6e "First definition."
 

--- a/test/output-expected/config-linking/headingIdAlgorithm/unsupported/book-index.md
+++ b/test/output-expected/config-linking/headingIdAlgorithm/unsupported/book-index.md
@@ -2,7 +2,7 @@
 
 ## [Alpha](#alpha)
 
-[Glossary 1][1] ○ [Glossary 2][2] ○ [Document 1][3] ○ [Document 2][4]
+[Glossary 1][1] ○ [Glossary 2][2] ○ [**Document 1**][3] ○ [**Document 2**][4]
 
 [1]: ./glossary-1.md#alpha "First definition."
 

--- a/test/package.json
+++ b/test/package.json
@@ -129,6 +129,7 @@
     "test_p12__05": "node . --config ./input/config-indexFile/issue-75-formatted-headings/glossarify-md.conf.json",
     "test_p12__06": "node . --config ./input/config-indexFiles/flat-dir/glossarify-md.conf.json",
     "test_p12__07": "node . --config ./input/config-indexFiles/154-deep-dir/glossarify-md.conf.json",
+    "test_p12__08": "node . --config ./input/config-indexFiles/hideDeepLinks/glossarify-md.conf.json",
     "test_p13__00": "node . --config ./input/config-listOf/basic/glossarify-md.conf.json",
     "test_p13__01": "node . --config ./input/config-listOf/pattern-tc1-text-paragraph/glossarify-md.conf.json",
     "test_p13__02": "node . --config ./input/config-listOf/pattern-tc2-formatted-paragraph/glossarify-md.conf.json",


### PR DESCRIPTION
- Render index entries which are page titles **bold**.
- Allow hiding numbered "deep" subsection links (which are deeper than `indexing.groupByHeadingDepth`.