### PR TITLE
chore(docs): Glossarify References

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 # Contributing
 
-[VSCode]: https://code.visualstudio.com
-
 [launch configuration]: ./.vscode/launch.json
 
 ## Table of Contents
@@ -28,7 +26,7 @@
 
 - [`git`](https://git-scm.com)
 - [`node` and `npm`](https://nodejs.org) - we aim to support the last two Node LTS releases ([Maintenance, Active](https://nodejs.org/en/about/releases/)) as well as the latest Non-LTS versions ([Current](https://nodejs.org/en/about/releases/))
-- Editor of your choice, e.g. [Atom](https://atom.io), [VSCode](https://code.visualstudio.com), etc.
+- Editor of your choice, e.g. Atom, VSCode, etc.
 
 > **⚠ Important (Windows-Users):** Configure your editor or IDE to use Unix-style line-endings (LF) for this project. Unix-Style-Endings are required at least for *Markdown*, *JS* and *JSON* files.
 
@@ -81,7 +79,7 @@ npm run experiment
 
 ## Debugging
 
-The project includes a [VSCode] `Debug Experiment` [launch configuration] for debugging [experiments](#experiments) with the internal debugger (`F5` key).
+The project includes a VSCode `Debug Experiment` [launch configuration] for debugging [experiments](#experiments) with the internal debugger (`F5` key).
 
 Alternatively
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+[VSCode]: https://code.visualstudio.com
+
 [launch configuration]: ./.vscode/launch.json
 
 ## Table of Contents
@@ -26,7 +28,7 @@
 
 - [`git`](https://git-scm.com)
 - [`node` and `npm`](https://nodejs.org) - we aim to support the last two Node LTS releases ([Maintenance, Active](https://nodejs.org/en/about/releases/)) as well as the latest Non-LTS versions ([Current](https://nodejs.org/en/about/releases/))
-- Editor of your choice, e.g. Atom, VSCode, etc.
+- Editor of your choice, e.g. [Atom](https://atom.io), [VSCode](https://code.visualstudio.com), etc.
 
 > **⚠ Important (Windows-Users):** Configure your editor or IDE to use Unix-style line-endings (LF) for this project. Unix-Style-Endings are required at least for *Markdown*, *JS* and *JSON* files.
 
@@ -79,7 +81,7 @@ npm run experiment
 
 ## Debugging
 
-The project includes a VSCode `Debug Experiment` [launch configuration] for debugging [experiments](#experiments) with the internal debugger (`F5` key).
+The project includes a [VSCode] `Debug Experiment` [launch configuration] for debugging [experiments](#experiments) with the internal debugger (`F5` key).
 
 Alternatively
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ vuepress users might be interested in learning [how to use the tool with vuepres
 - [Aliases and Synonyms](#aliases-and-synonyms)
 - [Term Hints](#term-hints)
 - [Multiple Glossaries](#multiple-glossaries)
-- [Sorting your glossaries](#sorting-your-glossaries)
+- [Sorting Glossaries](#sorting-glossaries)
 - [Cross Linking](#cross-linking)
   - [Term-Based Auto-Linking](#term-based-auto-linking)
   - [Identifier-based Cross-Linking](#identifier-based-cross-linking)
@@ -360,7 +360,7 @@ Sometimes you might whish to have multiple glossaries. For example as a Requirem
 
 By adding *requirements.md* to the list of glossaries every use of *REQ-1* or *REQ-2* in documents gets linked to the requirements glossary. To navigate the opposite direction from a requirement to sections where those got mentioned you can generate a [Book Index](#book-index).
 
-## Sorting your glossaries
+## Sorting Glossaries
 
 Add `sort` with `"asc"` (ascending) or `"desc"` (descending) to glossaries you want glossarify-md sort for you:
 
@@ -1002,7 +1002,7 @@ The relation to [`linking.headingDepths`](#linkingheadingdepths) is that *this* 
 }`
 ```
 
-Locale options to control [sorting](#sorting-your-glossaries). See [`Intl.Collator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/Collator).
+Locale options to control [sorting](#sorting-glossaries). See [`Intl.Collator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/Collator).
 
 #### `keepRawFiles`
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 ![Tests (Functional)](https://github.com/about-code/glossarify-md/workflows/Tests%20\(Functional\)/badge.svg)
 ![Nightly Tests (Latest Dependencies)](https://github.com/about-code/glossarify-md/workflows/Tests%20\(with%20latest%20deps\)/badge.svg)
 
-glossarify-md is a command line tool to help Markdown writers with
+[glossarify-md] is a command line tool to help Markdown writers with
 
 - **Cross-Linking** (primary use case): autolink terms to some definition in a glossary
 - **Indexes**: generate indexes from glossary terms and navigate to where they were mentioned
 - **Lists**: generate arbitrary lists such as *List of Tables*, *List of Figures*, *List of Listings*, *List of Definitions*, *List of Formulas*, and so forth...
 
-vuepress users might be interested in learning [how to use the tool with vuepress][doc-vuepress].
+[vuepress] users might be interested in learning [how to use the tool with vuepress][doc-vuepress].
 
 [doc-vocabulary-uris]: https://github.com/about-code/glossarify-md/blob/master/doc/vocabulary-uris.md
 
@@ -21,15 +21,37 @@ vuepress users might be interested in learning [how to use the tool with vuepres
 
 [doc-conceptual-layers]: https://github.com/about-code/glossarify-md/blob/master/doc/conceptual-layers.md
 
+[CommonMark]: https://www.commonmark.org
+
+[GFM]: https://github.github.com/gfm/
+
+[glob]: https://github.com/isaacs/node-glob#glob-primer
+
+[glossarify-md]: https://github.com/about-code/glossarify-md
+
+[jsonld]: https://npmjs.com/package/jsonld
+
 [link reference definitions]: https://spec.commonmark.org/0.30/#link-reference-definition
 
+[mdast]: https://github.com/syntax-tree/mdast
+
+[micromark]: https://github.com/micromark/
+
+[pandoc]: https://pandoc.org
+
 [pandoc-heading-ids]: https://pandoc.org/MANUAL.html#heading-identifiers
+
+[remark]: https://github.com/remarkjs/remark
 
 [remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
 
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
 
+[unified]: https://unifiedjs.com
+
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
+
+[vuepress]: https://vuepress.vuejs.org
 
 ## Table of Contents
 
@@ -212,7 +234,7 @@ Your document files may just use the term *Term* anywhere in text:
 This is a text which uses a glossary Term to describe something.
 ```
 
-Then run glossarify-md with a [glossarify-md.conf.json](#configuration):
+Then run [glossarify-md] with a [glossarify-md.conf.json](#configuration):
 
 ```
 npx glossarify-md --config ./glossarify-md.conf.json
@@ -330,7 +352,7 @@ In the output files aliases will be linked to their related term:
 
 Glossaries can be associated with *term hints*. Term hints may be used to indicate that a link refers to a glossary term and in case of [multiple glossaries][multiple-glossaries] to which one. Use `"${term}"` to control placement of a `termHint`. For example, `"☛ ${term}"` puts the symbol `☛` in front of a linkified term occurrence.
 
-> **ⓘ Since v5.0.0**: `file` can also be used with a glob pattern. More see [Cross-Linking].
+> **ⓘ Since v5.0.0**: `file` can also be used with a [glob] pattern. More see [Cross-Linking].
 
 ## Multiple Glossaries
 
@@ -362,7 +384,7 @@ By adding *requirements.md* to the list of glossaries every use of *REQ-1* or *R
 
 ## Sorting Glossaries
 
-Add `sort` with `"asc"` (ascending) or `"desc"` (descending) to glossaries you want glossarify-md sort for you:
+Add `sort` with `"asc"` (ascending) or `"desc"` (descending) to glossaries you want [glossarify-md] sort for you:
 
 *glossarify-md.conf.json*
 
@@ -395,7 +417,7 @@ The i18n-object is passed *as is* to the collator function. Thus you can use add
 
 *Term-based auto-linking* is what we've seen so far. It is to assume headings in markdown files called *glossaries* are *terms* that whenever being mentioned in text are being turned into a link to the glossary section where they have been defined as a term.
 
-**Since v5.0.0** we've added a few features which let us evolve that principle into a more generic means of cross-linking beginning with support for glob patterns in `glossaries.file`. For example with ...
+**Since v5.0.0** we've added a few features which let us evolve that principle into a more generic means of cross-linking beginning with support for [glob] patterns in `glossaries.file`. For example with ...
 
 ```json
 "glossaries": [
@@ -417,7 +439,7 @@ If the same section heading exists more than once then you might want to link to
 
 **Since v5.0.0** we've added support for manual cross-linking through [pandoc's concept of heading ids][pandoc-heading-ids]. These allow you to assign identifiers which are more stable for referencing than auto-generated IDs derived from the heading phrase (slugs).
 
-> **ⓘ Note:** Pandoc's identifier syntax is not standardized in CommonMark.
+> **ⓘ Note:** Pandoc's identifier syntax is not standardized in [CommonMark].
 
 [Sample]: document `./pages/page1.md` declares a heading
 
@@ -433,7 +455,7 @@ with heading-id `#s-241`. **Given that `#s-241` is *unique* across all documents
 [any phrase](#s-241)
 ```
 
-In any file being processed glossarify-md will resolve the actual path to the definition:
+In any file being processed [glossarify-md] will resolve the actual path to the definition:
 
 */README.md*
 
@@ -488,7 +510,7 @@ Let's assume you have multiple glossaries and you want to create separate book i
 }
 ```
 
-> **ⓘ Note:** If you plan on translating markdown to HTML, e.g. with vuepress(https://vuepress.vuejs.org), be aware that a file `index.md` will translate to `index.html` which is typically reserved for the default HTML file served under a domain. We recommend you choosing another name.
+> **ⓘ Note:** If you plan on translating markdown to HTML, e.g. with [vuepress](https://vuepress.vuejs.org), be aware that a file `index.md` will translate to `index.html` which is typically reserved for the default HTML file served under a domain. We recommend you choosing another name.
 
 ### Lists
 
@@ -570,13 +592,13 @@ The link label for list items will be inferred in this order (first-match):
 ### List of Figures
 
 So far we used [`listOf`](#lists) to generate a list from *HTML elements* in Markdown. Writing HTML can be annoying, particularly if there is handier Markdown syntax for the elements to be listed. This is where
-`listOfFigures` and [`listOfTables`](#list-of-tables) fit in. It is a shortcut which makes glossarify-md generate the HTML anchor itself from Markdown's image syntax:
+`listOfFigures` and [`listOfTables`](#list-of-tables) fit in. It is a shortcut which makes [glossarify-md] generate the HTML anchor itself from Markdown's image syntax:
 
 ```md
 ![List item Label](./figure.png)
 ```
 
-Then you may only need to use HTML for dynamically rendered figures, e.g. a PlantUML diagram:
+Then you may only need to use HTML for dynamically rendered figures, e.g. a [PlantUML](https://plantuml.com) diagram:
 
 ````md
 <figure id="figure-gen">Dynamically Rendered Diagram</figure>
@@ -588,7 +610,7 @@ Then you may only need to use HTML for dynamically rendered figures, e.g. a Plan
 ```
 ````
 
-To compile both figures into the same list one way to configure glossarify-md is to declare a `listOf` class *figure* (for HTML elements) and tell `listOfFigures` (for `![]()` images) to use the same classifier *figure*:
+To compile both figures into the same list one way to configure [glossarify-md] is to declare a `listOf` class *figure* (for HTML elements) and tell `listOfFigures` (for `![]()` images) to use the same classifier *figure*:
 
 *glossarify-md.conf.json* (since v5.0.0)
 
@@ -633,7 +655,7 @@ This configuration which would allow you to also choose a shorter classifier lik
 }
 ```
 
-In contrast to images Markdown tables have no notion of a table caption. To render a list item for a table glossarify-md tries to infer a list item label.
+In contrast to images Markdown tables have no notion of a table caption. To render a list item for a table [glossarify-md] tries to infer a list item label.
 
 One such inference looks at the **paragraph preceding the table**. If it **ends with an *emphasized* phrase** and the phrase itself is **terminated by a colon** then the tool uses that phrase as the item label:
 
@@ -682,7 +704,7 @@ The result for the tables above will be:
 > - [Average prices by category](#average-prices-by-category)
 > - [Average Prices by Article Category](#avg-prices)
 
-**Since v5.0.0** and the introduction of `listOf` all the previous examples will make glossarify-md annotate the table with an HTML anchor. So while not recommended due to verbosity, you could of course also just add an HTML anchor yourself, like described in [`listOf`](#lists):
+**Since v5.0.0** and the introduction of `listOf` all the previous examples will make [glossarify-md] annotate the table with an HTML anchor. So while not recommended due to verbosity, you could of course also just add an HTML anchor yourself, like described in [`listOf`](#lists):
 
 ```md
 <a id="avg-prices" class="table" title="Average Prices by Article Category"></a>
@@ -694,7 +716,7 @@ The result for the tables above will be:
 | 3        | Book        | $23.45     |
 ```
 
-> **ⓘ Note:** If glossarify-md can't find a list item label by any of the above means it will fall back to rendering a list item
+> **ⓘ Note:** If [glossarify-md] can't find a list item label by any of the above means it will fall back to rendering a list item
 >
 > 1. using the table headers separated by comma,
 > 1. or if no headers, using the closest section heading
@@ -744,7 +766,7 @@ If the regular expression (RegExp) matches text in a paragraph, then *the paragr
 
 > **ⓘ When to consider "markdown syntax" in the RegExp**:
 >
-> You may noticed that the RegExp above doesn't assume *Task:* to be written between "bold" star markers `**`. The expression won't be matched against the input *you* wrote but against *plain text* cleaned from symbols contributing to CommonMark or GFM syntax.
+> You may noticed that the RegExp above doesn't assume *Task:* to be written between "bold" star markers `**`. The expression won't be matched against the input *you* wrote but against *plain text* cleaned from symbols contributing to [CommonMark] or [GFM] syntax.
 >
 > In case you use another Markdown flavor see our addendum on [Markdown Syntax Extensions][doc-syntax-extensions]. Without a proper plug-in its syntactical elements are likely considered plain text, too. Then they need to be taken care of in the RegExp to make it match.
 
@@ -752,9 +774,9 @@ If the regular expression (RegExp) matches text in a paragraph, then *the paragr
 
 [doc-export-import]: #structured-export-and-import
 
-SKOS: https://w3.org/skos
+[SKOS]: https://w3.org/skos
 
-**Since v6.0.0** glossary terms can be exported to a structured JSON format (file extension `.json`). When jsonld is installed alongside glossarify-md then terms can also be exported to RDF N-Quads (file extension `.nq`).
+**Since v6.0.0** glossary terms can be exported to a structured JSON format (file extension `.json`). When [jsonld] is installed alongside glossarify-md then terms can also be exported to RDF N-Quads (file extension `.nq`).
 
 *glossarify-md.conf.json* (generates ./glossary.json)
 
@@ -770,7 +792,7 @@ SKOS: https://w3.org/skos
 }
 ```
 
-Declare a glossary `uri` when exporting. It will make glossarify-md assign each term a *uniform resource identifier* by combining the glossary's `uri` with a term's book-internal identifier (see [`headingIdAlgorithm`][headingIdAlgorithm]). Note that URIs are not required to resolve to some web page but *can* do so. More on the idea behind URIs read [here][doc-vocabulary-uris]. You can import terms the same way using `import` instead.
+Declare a glossary `uri` when exporting. It will make [glossarify-md] assign each term a *uniform resource identifier* by combining the glossary's `uri` with a term's book-internal identifier (see [`headingIdAlgorithm`][headingIdAlgorithm]). Note that URIs are not required to resolve to some web page but *can* do so. More on the idea behind URIs read [here][doc-vocabulary-uris]. You can import terms the same way using `import` instead.
 
 *glossarify-md.conf.json* (generates ./glossary.md):
 
@@ -786,7 +808,7 @@ Declare a glossary `uri` when exporting. It will make glossarify-md assign each 
 }
 ```
 
-> ⚠ **Important:** glossarify-md is able to import JSON glossaries from a remote location using `https`. While it will try to remove any Markdown and HTML from imported term definitions using [strip-markdown](https://npmjs.com/package/strip-markdown) it can only do so after `JSON.parse()`. As a rule of thumb never import from untrusted sources and assume that any files from a remote location could enable a remote entity to embed malicious code into outputs or execute such code in the runtime context of glossarify-md. Consider importing files statically after review.
+> ⚠ **Important:** [glossarify-md] is able to import JSON glossaries from a remote location using `https`. While it will try to remove any Markdown and HTML from imported term definitions using [strip-markdown](https://npmjs.com/package/strip-markdown) it can only do so after `JSON.parse()`. As a rule of thumb never import from untrusted sources and assume that any files from a remote location could enable a remote entity to embed malicious code into outputs or execute such code in the runtime context of [glossarify-md]. Consider importing files statically after review.
 
 Advanced topics on importing and exporting can be found [here](https://github.com/about-code/glossarify-md/blob/master/doc/skos-interop.md).
 
@@ -796,7 +818,7 @@ The term *support* refers to *runs on the given platform* and is subject to the 
 
 | NodeJS  | glossarify-md |                                                                           Current Test Matrix                                                                            |
 | ------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Current | v6+           | Tested. Should node.js introduce breaking changes which affect glossarify-md, then we may choose to step back from supporting *Current* until it becomes the next LTS. |
+| Current | v6+           | Tested. Should node.js introduce breaking changes which affect [glossarify-md], then we may choose to step back from supporting *Current* until it becomes the next LTS. |
 | 16 LTS  | v5, v6+       | Tested + Supported                                                                                                                                                       |
 | 14 LTS  | v4, v5, v6+   | Tested + Supported                                                                                                                                                       |
 | 12 LTS  | v3, v4, v5    |                                                                                                                                                                          |
@@ -1051,7 +1073,7 @@ Whether to convert inline-links to [link reference definitions] (size-efficient)
 - **Default:** `true`
 - **Since:** v6.0.0
 
-Whether to linkify headings. Note that some Markdown-to-HTML renderers need headings to be linkified in order to be rendered URL-addressable and navigable. Others like pandoc don't need linkified headings but special syntax.
+Whether to linkify headings. Note that some Markdown-to-HTML renderers need headings to be linkified in order to be rendered URL-addressable and navigable. Others like [pandoc] don't need linkified headings but special syntax.
 
 See also:
 
@@ -1095,9 +1117,9 @@ where `baseUrl` will be used only if there's no glossary uri. The `*-7` hashsum 
 - **Default:** false
 - **Since:** v6.0.0
 
-Since v5 there has been support for *parsing* pandoc-style heading IDs from input markdown. In v6 we added support for *writing*  pandoc-style `{#id}` identifiers to output markdown to facilitate postprocessing with pandoc.
+Since v5 there has been support for *parsing* pandoc-style heading IDs from input markdown. In v6 we added support for *writing*  pandoc-style `{#id}` identifiers to output markdown to facilitate postprocessing with [pandoc].
 
-> **ⓘ Note:** Pandoc's identifier syntax is not standardized in CommonMark.
+> **ⓘ Note:** Pandoc's identifier syntax is not standardized in [CommonMark].
 
 See also
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 ![Tests (Functional)](https://github.com/about-code/glossarify-md/workflows/Tests%20\(Functional\)/badge.svg)
 ![Nightly Tests (Latest Dependencies)](https://github.com/about-code/glossarify-md/workflows/Tests%20\(with%20latest%20deps\)/badge.svg)
 
-[glossarify-md] is a command line tool to help Markdown writers with
+glossarify-md is a command line tool to help Markdown writers with
 
 - **Cross-Linking** (primary use case): autolink terms to some definition in a glossary
 - **Indexes**: generate indexes from glossary terms and navigate to where they were mentioned
 - **Lists**: generate arbitrary lists such as *List of Tables*, *List of Figures*, *List of Listings*, *List of Definitions*, *List of Formulas*, and so forth...
 
-[vuepress] users might be interested in learning [how to use the tool with vuepress][doc-vuepress].
+vuepress users might be interested in learning [how to use the tool with vuepress][doc-vuepress].
 
 [doc-vocabulary-uris]: https://github.com/about-code/glossarify-md/blob/master/doc/vocabulary-uris.md
 
@@ -21,37 +21,15 @@
 
 [doc-conceptual-layers]: https://github.com/about-code/glossarify-md/blob/master/doc/conceptual-layers.md
 
-[CommonMark]: https://www.commonmark.org
-
-[GFM]: https://github.github.com/gfm/
-
-[glob]: https://github.com/isaacs/node-glob#glob-primer
-
-[glossarify-md]: https://github.com/about-code/glossarify-md
-
-[jsonld]: https://npmjs.com/package/jsonld
-
 [link reference definitions]: https://spec.commonmark.org/0.30/#link-reference-definition
 
-[mdast]: https://github.com/syntax-tree/mdast
-
-[micromark]: https://github.com/micromark/
-
-[pandoc]: https://pandoc.org
-
 [pandoc-heading-ids]: https://pandoc.org/MANUAL.html#heading-identifiers
-
-[remark]: https://github.com/remarkjs/remark
 
 [remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
 
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
 
-[unified]: https://unifiedjs.com
-
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
-
-[vuepress]: https://vuepress.vuejs.org
 
 ## Table of Contents
 
@@ -234,7 +212,7 @@ Your document files may just use the term *Term* anywhere in text:
 This is a text which uses a glossary Term to describe something.
 ```
 
-Then run [glossarify-md] with a [glossarify-md.conf.json](#configuration):
+Then run glossarify-md with a [glossarify-md.conf.json](#configuration):
 
 ```
 npx glossarify-md --config ./glossarify-md.conf.json
@@ -352,7 +330,7 @@ In the output files aliases will be linked to their related term:
 
 Glossaries can be associated with *term hints*. Term hints may be used to indicate that a link refers to a glossary term and in case of [multiple glossaries][multiple-glossaries] to which one. Use `"${term}"` to control placement of a `termHint`. For example, `"☛ ${term}"` puts the symbol `☛` in front of a linkified term occurrence.
 
-> **ⓘ Since v5.0.0**: `file` can also be used with a [glob] pattern. More see [Cross-Linking].
+> **ⓘ Since v5.0.0**: `file` can also be used with a glob pattern. More see [Cross-Linking].
 
 ## Multiple Glossaries
 
@@ -384,7 +362,7 @@ By adding *requirements.md* to the list of glossaries every use of *REQ-1* or *R
 
 ## Sorting your glossaries
 
-Add `sort` with `"asc"` (ascending) or `"desc"` (descending) to glossaries you want [glossarify-md] sort for you:
+Add `sort` with `"asc"` (ascending) or `"desc"` (descending) to glossaries you want glossarify-md sort for you:
 
 *glossarify-md.conf.json*
 
@@ -417,7 +395,7 @@ The i18n-object is passed *as is* to the collator function. Thus you can use add
 
 *Term-based auto-linking* is what we've seen so far. It is to assume headings in markdown files called *glossaries* are *terms* that whenever being mentioned in text are being turned into a link to the glossary section where they have been defined as a term.
 
-**Since v5.0.0** we've added a few features which let us evolve that principle into a more generic means of cross-linking beginning with support for [glob] patterns in `glossaries.file`. For example with ...
+**Since v5.0.0** we've added a few features which let us evolve that principle into a more generic means of cross-linking beginning with support for glob patterns in `glossaries.file`. For example with ...
 
 ```json
 "glossaries": [
@@ -439,7 +417,7 @@ If the same section heading exists more than once then you might want to link to
 
 **Since v5.0.0** we've added support for manual cross-linking through [pandoc's concept of heading ids][pandoc-heading-ids]. These allow you to assign identifiers which are more stable for referencing than auto-generated IDs derived from the heading phrase (slugs).
 
-> **ⓘ Note:** Pandoc's identifier syntax is not standardized in [CommonMark].
+> **ⓘ Note:** Pandoc's identifier syntax is not standardized in CommonMark.
 
 [Sample]: document `./pages/page1.md` declares a heading
 
@@ -455,7 +433,7 @@ with heading-id `#s-241`. **Given that `#s-241` is *unique* across all documents
 [any phrase](#s-241)
 ```
 
-In any file being processed [glossarify-md] will resolve the actual path to the definition:
+In any file being processed glossarify-md will resolve the actual path to the definition:
 
 */README.md*
 
@@ -510,7 +488,7 @@ Let's assume you have multiple glossaries and you want to create separate book i
 }
 ```
 
-> **ⓘ Note:** If you plan on translating markdown to HTML, e.g. with [vuepress](https://vuepress.vuejs.org), be aware that a file `index.md` will translate to `index.html` which is typically reserved for the default HTML file served under a domain. We recommend you choosing another name.
+> **ⓘ Note:** If you plan on translating markdown to HTML, e.g. with vuepress(https://vuepress.vuejs.org), be aware that a file `index.md` will translate to `index.html` which is typically reserved for the default HTML file served under a domain. We recommend you choosing another name.
 
 ### Lists
 
@@ -592,13 +570,13 @@ The link label for list items will be inferred in this order (first-match):
 ### List of Figures
 
 So far we used [`listOf`](#lists) to generate a list from *HTML elements* in Markdown. Writing HTML can be annoying, particularly if there is handier Markdown syntax for the elements to be listed. This is where
-`listOfFigures` and [`listOfTables`](#list-of-tables) fit in. It is a shortcut which makes [glossarify-md] generate the HTML anchor itself from Markdown's image syntax:
+`listOfFigures` and [`listOfTables`](#list-of-tables) fit in. It is a shortcut which makes glossarify-md generate the HTML anchor itself from Markdown's image syntax:
 
 ```md
 ![List item Label](./figure.png)
 ```
 
-Then you may only need to use HTML for dynamically rendered figures, e.g. a [PlantUML](https://plantuml.com) diagram:
+Then you may only need to use HTML for dynamically rendered figures, e.g. a PlantUML diagram:
 
 ````md
 <figure id="figure-gen">Dynamically Rendered Diagram</figure>
@@ -610,7 +588,7 @@ Then you may only need to use HTML for dynamically rendered figures, e.g. a [Pla
 ```
 ````
 
-To compile both figures into the same list one way to configure [glossarify-md] is to declare a `listOf` class *figure* (for HTML elements) and tell `listOfFigures` (for `![]()` images) to use the same classifier *figure*:
+To compile both figures into the same list one way to configure glossarify-md is to declare a `listOf` class *figure* (for HTML elements) and tell `listOfFigures` (for `![]()` images) to use the same classifier *figure*:
 
 *glossarify-md.conf.json* (since v5.0.0)
 
@@ -655,7 +633,7 @@ This configuration which would allow you to also choose a shorter classifier lik
 }
 ```
 
-In contrast to images Markdown tables have no notion of a table caption. To render a list item for a table [glossarify-md] tries to infer a list item label.
+In contrast to images Markdown tables have no notion of a table caption. To render a list item for a table glossarify-md tries to infer a list item label.
 
 One such inference looks at the **paragraph preceding the table**. If it **ends with an *emphasized* phrase** and the phrase itself is **terminated by a colon** then the tool uses that phrase as the item label:
 
@@ -704,7 +682,7 @@ The result for the tables above will be:
 > - [Average prices by category](#average-prices-by-category)
 > - [Average Prices by Article Category](#avg-prices)
 
-**Since v5.0.0** and the introduction of `listOf` all the previous examples will make [glossarify-md] annotate the table with an HTML anchor. So while not recommended due to verbosity, you could of course also just add an HTML anchor yourself, like described in [`listOf`](#lists):
+**Since v5.0.0** and the introduction of `listOf` all the previous examples will make glossarify-md annotate the table with an HTML anchor. So while not recommended due to verbosity, you could of course also just add an HTML anchor yourself, like described in [`listOf`](#lists):
 
 ```md
 <a id="avg-prices" class="table" title="Average Prices by Article Category"></a>
@@ -716,7 +694,7 @@ The result for the tables above will be:
 | 3        | Book        | $23.45     |
 ```
 
-> **ⓘ Note:** If [glossarify-md] can't find a list item label by any of the above means it will fall back to rendering a list item
+> **ⓘ Note:** If glossarify-md can't find a list item label by any of the above means it will fall back to rendering a list item
 >
 > 1. using the table headers separated by comma,
 > 1. or if no headers, using the closest section heading
@@ -766,7 +744,7 @@ If the regular expression (RegExp) matches text in a paragraph, then *the paragr
 
 > **ⓘ When to consider "markdown syntax" in the RegExp**:
 >
-> You may noticed that the RegExp above doesn't assume *Task:* to be written between "bold" star markers `**`. The expression won't be matched against the input *you* wrote but against *plain text* cleaned from symbols contributing to [CommonMark] or [GFM] syntax.
+> You may noticed that the RegExp above doesn't assume *Task:* to be written between "bold" star markers `**`. The expression won't be matched against the input *you* wrote but against *plain text* cleaned from symbols contributing to CommonMark or GFM syntax.
 >
 > In case you use another Markdown flavor see our addendum on [Markdown Syntax Extensions][doc-syntax-extensions]. Without a proper plug-in its syntactical elements are likely considered plain text, too. Then they need to be taken care of in the RegExp to make it match.
 
@@ -774,9 +752,9 @@ If the regular expression (RegExp) matches text in a paragraph, then *the paragr
 
 [doc-export-import]: #structured-export-and-import
 
-[SKOS]: https://w3.org/skos
+SKOS: https://w3.org/skos
 
-**Since v6.0.0** glossary terms can be exported to a structured JSON format (file extension `.json`). When [jsonld] is installed alongside glossarify-md then terms can also be exported to RDF N-Quads (file extension `.nq`).
+**Since v6.0.0** glossary terms can be exported to a structured JSON format (file extension `.json`). When jsonld is installed alongside glossarify-md then terms can also be exported to RDF N-Quads (file extension `.nq`).
 
 *glossarify-md.conf.json* (generates ./glossary.json)
 
@@ -792,7 +770,7 @@ If the regular expression (RegExp) matches text in a paragraph, then *the paragr
 }
 ```
 
-Declare a glossary `uri` when exporting. It will make [glossarify-md] assign each term a *uniform resource identifier* by combining the glossary's `uri` with a term's book-internal identifier (see [`headingIdAlgorithm`][headingIdAlgorithm]). Note that URIs are not required to resolve to some web page but *can* do so. More on the idea behind URIs read [here][doc-vocabulary-uris]. You can import terms the same way using `import` instead.
+Declare a glossary `uri` when exporting. It will make glossarify-md assign each term a *uniform resource identifier* by combining the glossary's `uri` with a term's book-internal identifier (see [`headingIdAlgorithm`][headingIdAlgorithm]). Note that URIs are not required to resolve to some web page but *can* do so. More on the idea behind URIs read [here][doc-vocabulary-uris]. You can import terms the same way using `import` instead.
 
 *glossarify-md.conf.json* (generates ./glossary.md):
 
@@ -808,7 +786,7 @@ Declare a glossary `uri` when exporting. It will make [glossarify-md] assign eac
 }
 ```
 
-> ⚠ **Important:** [glossarify-md] is able to import JSON glossaries from a remote location using `https`. While it will try to remove any Markdown and HTML from imported term definitions using [strip-markdown](https://npmjs.com/package/strip-markdown) it can only do so after `JSON.parse()`. As a rule of thumb never import from untrusted sources and assume that any files from a remote location could enable a remote entity to embed malicious code into outputs or execute such code in the runtime context of [glossarify-md]. Consider importing files statically after review.
+> ⚠ **Important:** glossarify-md is able to import JSON glossaries from a remote location using `https`. While it will try to remove any Markdown and HTML from imported term definitions using [strip-markdown](https://npmjs.com/package/strip-markdown) it can only do so after `JSON.parse()`. As a rule of thumb never import from untrusted sources and assume that any files from a remote location could enable a remote entity to embed malicious code into outputs or execute such code in the runtime context of glossarify-md. Consider importing files statically after review.
 
 Advanced topics on importing and exporting can be found [here](https://github.com/about-code/glossarify-md/blob/master/doc/skos-interop.md).
 
@@ -818,7 +796,7 @@ The term *support* refers to *runs on the given platform* and is subject to the 
 
 | NodeJS  | glossarify-md |                                                                           Current Test Matrix                                                                            |
 | ------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Current | v6+           | Tested. Should node.js introduce breaking changes which affect [glossarify-md], then we may choose to step back from supporting *Current* until it becomes the next LTS. |
+| Current | v6+           | Tested. Should node.js introduce breaking changes which affect glossarify-md, then we may choose to step back from supporting *Current* until it becomes the next LTS. |
 | 16 LTS  | v5, v6+       | Tested + Supported                                                                                                                                                       |
 | 14 LTS  | v4, v5, v6+   | Tested + Supported                                                                                                                                                       |
 | 12 LTS  | v3, v4, v5    |                                                                                                                                                                          |
@@ -1073,7 +1051,7 @@ Whether to convert inline-links to [link reference definitions] (size-efficient)
 - **Default:** `true`
 - **Since:** v6.0.0
 
-Whether to linkify headings. Note that some Markdown-to-HTML renderers need headings to be linkified in order to be rendered URL-addressable and navigable. Others like [pandoc] don't need linkified headings but special syntax.
+Whether to linkify headings. Note that some Markdown-to-HTML renderers need headings to be linkified in order to be rendered URL-addressable and navigable. Others like pandoc don't need linkified headings but special syntax.
 
 See also:
 
@@ -1117,9 +1095,9 @@ where `baseUrl` will be used only if there's no glossary uri. The `*-7` hashsum 
 - **Default:** false
 - **Since:** v6.0.0
 
-Since v5 there has been support for *parsing* pandoc-style heading IDs from input markdown. In v6 we added support for *writing*  pandoc-style `{#id}` identifiers to output markdown to facilitate postprocessing with [pandoc].
+Since v5 there has been support for *parsing* pandoc-style heading IDs from input markdown. In v6 we added support for *writing*  pandoc-style `{#id}` identifiers to output markdown to facilitate postprocessing with pandoc.
 
-> **ⓘ Note:** Pandoc's identifier syntax is not standardized in [CommonMark].
+> **ⓘ Note:** Pandoc's identifier syntax is not standardized in CommonMark.
 
 See also
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -73,11 +73,11 @@ Dealing with Non-Standard Markdown Syntax
 
 Glossary
 
-*   [Glossary\*][doc-glossary] (of \[glossarify-md…]\[1])
+*   [Glossary\*][doc-glossary] (of \[[glossarify-md…][19]…]\[1])
 
 Developer Resources
 
-*   \[Conceptual Layers of glossarify-md\*]\[doc-dev-conceptual-layers]
+*   \[Conceptual Layers of [glossarify-md…][19]\*]\[doc-dev-conceptual-layers]
 *   \[The Parsing Process and Custom Node Types\*]\[doc-dev-node-types]
 
 Known Issues
@@ -119,3 +119,5 @@ Known Issues
 [17]: ../README.md#lists-from-regular-expressions
 
 [18]: ../README.md#structured-export-and-import
+
+[19]: https://github.com/about-code/glossarify-md "This project."

--- a/doc/README.md
+++ b/doc/README.md
@@ -16,23 +16,9 @@
 
 [doc-glossary]: ./glossary.md
 
-[SKOS]: http://w3.org/skos/
-
-[LD]: https://www.w3.org/standards/semanticweb/ontology
-
-[JSON-LD]: https://json-ld.org
-
-[jsonld]: https://npmjs.com/package/jsonld
-
-[vocabularies]: https://www.w3.org/standards/semanticweb/ontology
-
-[glossarify-md]: https://github.com/about-code/glossarify-md
-
-[OWL]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/
-
 # [Advanced Topics](#advanced-topics)
 
-[Glossary][doc-glossary] (of glossarify-md)
+[Glossary][doc-glossary] (of [glossarify-md][1])
 
 Markdown Syntax
 
@@ -56,3 +42,5 @@ Internals
 Known Issues
 
 *   [Generated Lists and Links on GitHub][doc-lists-on-github]
+
+[1]: https://github.com/about-code/glossarify-md "This project."

--- a/doc/README.md
+++ b/doc/README.md
@@ -58,7 +58,6 @@ Publishing
 
 *   [Using glossarify-md with vuepress\*][doc-vuepress]
 *   [Using glossarify-md with pandoc\*][doc-pandoc]
-*   [Path Rewriting\*][doc-path-rewriting]
 
 Exporting and Importing Terms
 
@@ -73,7 +72,7 @@ Dealing with Non-Standard Markdown Syntax
 
 Glossary
 
-*   [Glossary\*][doc-glossary] (of \[[glossarify-md][19]…]\[1])
+*   [Glossary\*][doc-glossary] (Terms of [glossarify-md][19])
 
 Developer Resources
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -73,11 +73,11 @@ Dealing with Non-Standard Markdown Syntax
 
 Glossary
 
-*   [Glossary\*][doc-glossary] (of \[[glossarify-md…][19]…]\[1])
+*   [Glossary\*][doc-glossary] (of \[[glossarify-md][19]…]\[1])
 
 Developer Resources
 
-*   \[Conceptual Layers of [glossarify-md…][19]\*]\[doc-dev-conceptual-layers]
+*   \[Conceptual Layers of [glossarify-md][19]\*]\[doc-dev-conceptual-layers]
 *   \[The Parsing Process and Custom Node Types\*]\[doc-dev-node-types]
 
 Known Issues

--- a/doc/README.md
+++ b/doc/README.md
@@ -18,7 +18,7 @@
 
 # [Advanced Topics](#advanced-topics)
 
-[Glossary][doc-glossary] (of [glossarify-md][1])
+[Glossary][doc-glossary] (of [glossarify-md⎆][1])
 
 Markdown Syntax
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,46 +1,121 @@
-[doc-vocabulary-uris]: ./vocabulary-uris.md
-
-[doc-skos-interop]: ./skos-interop.md
-
-[doc-vuepress]: ./vuepress.md
-
-[doc-syntax-extensions]: ./markdown-syntax-extensions.md
-
 [doc-conceptual-layers]: ./conceptual-layers.md
+
+[doc-glossary]: ./glossary.md
 
 [doc-lists-on-github]: ./lists-on-github.md
 
 [doc-pandoc]: ./pandoc.md
 
+[doc-path-rewriting]: ./path-rewriting.md
+
 [doc-plugins]: ./plugins.md
 
-[doc-glossary]: ./glossary.md
+[doc-vocabulary-uris]: ./vocabulary-uris.md
 
-# [Advanced Topics](#advanced-topics)
+[doc-vuepress]: ./vuepress.md
 
-[Glossary][doc-glossary] (of [glossarify-md⎆][1])
+[doc-references]: ./references.md
 
-Markdown Syntax
+[doc-skos-interop]: ./skos-interop.md
 
-*   [Markdown Syntax Extensions][doc-syntax-extensions]
-*   [Installing Syntax Plug-ins][doc-plugins]
+[doc-syntax-extensions]: ./markdown-syntax-extensions.md
 
-Exporting and Importing
+[README.md]: ../README.md
 
-*   [URIs as Identifiers for Definitions of Meaning][doc-vocabulary-uris]
-*   [Interoperability with SKOS and JSON-LD][doc-skos-interop]
+# [Documentation](#documentation)
 
-Further Processing
+Alternative Table of Contents for [README.md].
+Sections marked with \* add content *not* found in the README.
 
-*   [Using glossarify-md with vuepress][doc-vuepress]
-*   [Using glossarify-md with pandoc][doc-pandoc]
+Setup
 
-Internals
+*   [Install][1]
+*   [Configuration][2]
+    *   [Options][3]
+*   [Node Support Matrix][4]
 
-*   [Conceptual Layers of glossarify-md][doc-conceptual-layers]
+Glossary Basics
+
+*   [Basic Glossary Example][5]
+*   [Aliases and Synonyms][6]
+*   [Term Hints][7]
+*   [Multiple Glossaries][8]
+*   [Sorting Glossaries][9]
+
+Book Writing
+
+*   [Cross Linking][10]
+    *   [Term-Based Auto-Linking][11]
+    *   [Identifier-based Cross-Linking][12]
+*   [References\*][doc-references]
+*   [Book Index][13]
+*   [Lists][14]
+    *   [List of Figures][15]
+    *   [List of Tables][16]
+    *   [Lists from Regular Expressions][17]
+
+Publishing
+
+*   [Using glossarify-md with vuepress\*][doc-vuepress]
+*   [Using glossarify-md with pandoc\*][doc-pandoc]
+*   [Path Rewriting\*][doc-path-rewriting]
+
+Exporting and Importing Terms
+
+*   [Basics][18]
+*   [URIs as Identifiers for Definitions of Meaning\*][doc-vocabulary-uris]
+*   [Interoperability with SKOS and JSON-LD\*][doc-skos-interop]
+
+Dealing with Non-Standard Markdown Syntax
+
+*   [Markdown Syntax Extensions\*][doc-syntax-extensions]
+*   [Installing Syntax Plug-ins\*][doc-plugins]
+
+Glossary
+
+*   [Glossary\*][doc-glossary] (of \[glossarify-md…]\[1])
+
+Developer Resources
+
+*   \[Conceptual Layers of glossarify-md\*]\[doc-dev-conceptual-layers]
+*   \[The Parsing Process and Custom Node Types\*]\[doc-dev-node-types]
 
 Known Issues
 
-*   [Generated Lists and Links on GitHub][doc-lists-on-github]
+*   [Generated Lists and Links on GitHub\*][doc-lists-on-github]
 
-[1]: https://github.com/about-code/glossarify-md "This project."
+[1]: ../README.md#install
+
+[2]: ./README.md#configuration
+
+[3]: ../README.md#options
+
+[4]: ../README.md#node-support-matrix
+
+[5]: ../README.md#sample
+
+[6]: ../README.md#aliases-and-synonyms
+
+[7]: ../README.md#term-hints
+
+[8]: ../README.md#multiple-glossaries
+
+[9]: ../README.md#sorting-glossaries
+
+[10]: ../README.md#cross-linking
+
+[11]: ../README.md#term-based-auto-linking
+
+[12]: ../README.md#identifier-based-cross-linking
+
+[13]: ../README.md#book-index
+
+[14]: ../README.md#lists
+
+[15]: ../README.md#list-of-figures
+
+[16]: ../README.md#list-of-tables
+
+[17]: ../README.md#lists-from-regular-expressions
+
+[18]: ../README.md#structured-export-and-import

--- a/doc/_references.md
+++ b/doc/_references.md
@@ -4,7 +4,7 @@
 
 <!--{"uri": "https://atom.io" }-->
 
-[Atom…][1] Code Editor.
+[Atom][1] Code Editor.
 
 ## [CommonMark](#commonmark)
 
@@ -19,7 +19,7 @@ Effort on providing a minimal set of standardized Markdown syntax.
     "aliases": "DC, DublinCore, dc:"
 }-->
 
-The [Dublin Core…][2] Metadata Initiative.
+The [Dublin Core][2] Metadata Initiative.
 
 ## [GFM](#gfm)
 
@@ -28,19 +28,19 @@ The [Dublin Core…][2] Metadata Initiative.
     "aliases": "GFM, GitHub Flavoured Markdown, GitHub Flavored Markdown"
 }-->
 
-[GitHub Flavoured Markdown…][3]
+[GitHub Flavoured Markdown][3]
 
 ## [github-slugger](#github-slugger)
 
 <!--{"uri": "https://npmjs.com/package/github-slugger" }-->
 
-A library providing support for [slugs🟉][4]. See [github-slugger…][5].
+A library providing support for [slugs🟉][4]. See [github-slugger][5].
 
 ## [glob](#glob)
 
 <!--{"uri": "https://github.com/isaacs/node-glob#glob-primer" }-->
 
-A file pattern matcher. See [glob…][6].
+A file pattern matcher. See [glob][6].
 
 ## [glossarify-md](#glossarify-md)
 
@@ -61,7 +61,7 @@ A static website renderer compiling an HTML website from Markdown files.
     "aliases": "JSON-LD Spec"
 }-->
 
-[JSON-LD…][7] is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public [vocabularies🟉][8]. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. [SKOS…][9] is one such vocabulary supported by [glossarify-md…][10]
+[JSON-LD][7] is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public [vocabularies🟉][8]. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. [SKOS][9] is one such vocabulary supported by [glossarify-md][10]
 
 ## [jsonld Library](#jsonld-library)
 
@@ -70,7 +70,7 @@ A static website renderer compiling an HTML website from Markdown files.
     "aliases": "jsonld"
 }-->
 
-A JavaScript implementation of [JSON-LD…][7].
+A JavaScript implementation of [JSON-LD][7].
 
 ## [Linked Data](#linked-data)
 
@@ -79,7 +79,7 @@ A JavaScript implementation of [JSON-LD…][7].
     "aliases": "LD"
 }-->
 
-See [Linked Data…][11].
+See [Linked Data][11].
 
 ## [mdAst](#mdast)
 
@@ -94,13 +94,13 @@ Specification and Implementation of a Markdown Abstract Syntax Tree.
 
 <!--{"uri": "https://github.com/micromark/" }-->
 
-A low-level extensible implementation of the [CommonMark…][12] syntax specification (parsing and tokenizing).
+A low-level extensible implementation of the [CommonMark][12] syntax specification (parsing and tokenizing).
 
 ## [npm](#npm)
 
 <!-- {"uri": "https://npmjs.com"}-->
 
-Node Package Manager. See [npm…][13].
+Node Package Manager. See [npm][13].
 
 ## [OWL](#owl)
 
@@ -112,37 +112,37 @@ Web Ontology Language.
 
 <!--{"uri": "https://pandoc.org" }-->
 
-See [pandoc…][14].
+See [pandoc][14].
 
 ## [PlantUML](#plantuml)
 
 <!--{"uri": "https://plantuml.com" }-->
 
-Generates diagrams from text files written in the [PlantUML…][15] syntax.
+Generates diagrams from text files written in the [PlantUML][15] syntax.
 
 ## [remark](#remark)
 
 <!--{"uri": "https://github.com/remarkjs/remark" }-->
 
-*[remark…][16]* is a parser and compiler project under the [unified…][17] umbrella for *Markdown* text files in particular.
+*[remark][16]* is a parser and compiler project under the [unified][17] umbrella for *Markdown* text files in particular.
 
 ## [SKOS](#skos)
 
 <!--{ "uri": "http://w3.org/skos/" }-->
 
-With the Simple [Knowledge Organization System🟉][18] ([SKOS…][9]) the World Wide Web Consortium (W3C) has standardized a (meta-)[vocabulary🟉][8] which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
+With the Simple [Knowledge Organization System🟉][18] ([SKOS][9]) the World Wide Web Consortium (W3C) has standardized a (meta-)[vocabulary🟉][8] which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
 
 ## [unified](#unified)
 
 <!--{ "uri": "https://unifiedjs.com" }-->
 
-*[unified…][17]* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md][19]
+*[unified][17]* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md][19]
 
 ## [URN](#urn)
 
 <!--{ "uri": "https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml" }-->
 
-Uniform Resource Names. See [URN…][20].
+Uniform Resource Names. See [URN][20].
 
 ## [VSCode](#vscode)
 
@@ -150,7 +150,7 @@ Uniform Resource Names. See [URN…][20].
 
 [Code-OSS]: https://github.com/microsoft/vscode
 
-Visual Studio Code. See [VSCode…][21] or [Code-OSS].
+Visual Studio Code. See [VSCode][21] or [Code-OSS].
 
 ## [vuepress](#vuepress)
 

--- a/doc/_references.md
+++ b/doc/_references.md
@@ -4,7 +4,7 @@
 
 <!--{"uri": "https://atom.io" }-->
 
-Atom Code Editor.
+[Atom…][1] Code Editor.
 
 ## [CommonMark](#commonmark)
 
@@ -19,7 +19,7 @@ Effort on providing a minimal set of standardized Markdown syntax.
     "aliases": "DC, DublinCore, dc:"
 }-->
 
-The Dublin Core Metadata Initiative.
+The [Dublin Core…][2] Metadata Initiative.
 
 ## [GFM](#gfm)
 
@@ -28,19 +28,19 @@ The Dublin Core Metadata Initiative.
     "aliases": "GFM, GitHub Flavoured Markdown, GitHub Flavored Markdown"
 }-->
 
-GitHub Flavoured Markdown
+[GitHub Flavoured Markdown…][3]
 
 ## [github-slugger](#github-slugger)
 
 <!--{"uri": "https://npmjs.com/package/github-slugger" }-->
 
-A library providing support for [slugs🟉][1]. See github-slugger.
+A library providing support for [slugs🟉][4]. See [github-slugger…][5].
 
 ## [glob](#glob)
 
 <!--{"uri": "https://github.com/isaacs/node-glob#glob-primer" }-->
 
-A file pattern matcher. See glob.
+A file pattern matcher. See [glob…][6].
 
 ## [glossarify-md](#glossarify-md)
 
@@ -61,7 +61,7 @@ A static website renderer compiling an HTML website from Markdown files.
     "aliases": "JSON-LD Spec"
 }-->
 
-JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public [vocabularies🟉][2]. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. SKOS is one such vocabulary supported by glossarify-md
+[JSON-LD…][7] is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public [vocabularies🟉][8]. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. [SKOS…][9] is one such vocabulary supported by [glossarify-md…][10]
 
 ## [jsonld Library](#jsonld-library)
 
@@ -70,7 +70,7 @@ JSON-LD is a standardized JSON document format for mapping system-specific terms
     "aliases": "jsonld"
 }-->
 
-A JavaScript implementation of JSON-LD.
+A JavaScript implementation of [JSON-LD…][7].
 
 ## [Linked Data](#linked-data)
 
@@ -79,7 +79,7 @@ A JavaScript implementation of JSON-LD.
     "aliases": "LD"
 }-->
 
-See Linked Data.
+See [Linked Data…][11].
 
 ## [mdAst](#mdast)
 
@@ -94,13 +94,13 @@ Specification and Implementation of a Markdown Abstract Syntax Tree.
 
 <!--{"uri": "https://github.com/micromark/" }-->
 
-A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing).
+A low-level extensible implementation of the [CommonMark…][12] syntax specification (parsing and tokenizing).
 
 ## [npm](#npm)
 
 <!-- {"uri": "https://npmjs.com"}-->
 
-Node Package Manager. See npm.
+Node Package Manager. See [npm…][13].
 
 ## [OWL](#owl)
 
@@ -112,37 +112,37 @@ Web Ontology Language.
 
 <!--{"uri": "https://pandoc.org" }-->
 
-See pandoc.
+See [pandoc…][14].
 
 ## [PlantUML](#plantuml)
 
 <!--{"uri": "https://plantuml.com" }-->
 
-Generates diagrams from text files written in the PlantUML syntax.
+Generates diagrams from text files written in the [PlantUML…][15] syntax.
 
 ## [remark](#remark)
 
 <!--{"uri": "https://github.com/remarkjs/remark" }-->
 
-*remark* is a parser and compiler project under the unified umbrella for *Markdown* text files in particular.
+*[remark…][16]* is a parser and compiler project under the [unified…][17] umbrella for *Markdown* text files in particular.
 
 ## [SKOS](#skos)
 
 <!--{ "uri": "http://w3.org/skos/" }-->
 
-With the Simple [Knowledge Organization System🟉][3] (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)[vocabulary🟉][2] which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
+With the Simple [Knowledge Organization System🟉][18] ([SKOS…][9]) the World Wide Web Consortium (W3C) has standardized a (meta-)[vocabulary🟉][8] which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
 
 ## [unified](#unified)
 
 <!--{ "uri": "https://unifiedjs.com" }-->
 
-*unified* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md][4]
+*[unified…][17]* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md][19]
 
 ## [URN](#urn)
 
 <!--{ "uri": "https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml" }-->
 
-Uniform Resource Names. See URN.
+Uniform Resource Names. See [URN…][20].
 
 ## [VSCode](#vscode)
 
@@ -150,7 +150,7 @@ Uniform Resource Names. See URN.
 
 [Code-OSS]: https://github.com/microsoft/vscode
 
-Visual Studio Code. See VSCode or [Code-OSS].
+Visual Studio Code. See [VSCode…][21] or [Code-OSS].
 
 ## [vuepress](#vuepress)
 
@@ -164,10 +164,44 @@ A static website generator translating markdown files into a website powered by 
 
 A Single Page Application framework written in JavaScript.
 
-[1]: ./glossary.md#slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
+[1]: https://atom.io "Atom Code Editor."
 
-[2]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
+[2]: http://purl.org/dc/terms/ "The Dublin Core Metadata Initiative."
 
-[3]: ./glossary.md#kos---knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
+[3]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"
 
-[4]: ./conceptual-layers.md
+[4]: ./glossary.md#slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
+
+[5]: https://npmjs.com/package/github-slugger "A library providing support for slugs."
+
+[6]: https://github.com/isaacs/node-glob#glob-primer "A file pattern matcher."
+
+[7]: https://json-ld.org "JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies."
+
+[8]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
+
+[9]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
+
+[10]: https://github.com/about-code/glossarify-md "This project."
+
+[11]: https://www.w3.org/standards/semanticweb/ontology "See Linked Data."
+
+[12]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+
+[13]: _references.md#npm "Node Package Manager."
+
+[14]: https://pandoc.org "See pandoc."
+
+[15]: https://plantuml.com "Generates diagrams from text files written in the PlantUML syntax."
+
+[16]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+
+[17]: https://unifiedjs.com "unified is an umbrella project around text file processing in general."
+
+[18]: ./glossary.md#kos---knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
+
+[19]: ./conceptual-layers.md
+
+[20]: https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml "Uniform Resource Names."
+
+[21]: https://code.visualstudio.com "Visual Studio Code."

--- a/doc/_references.md
+++ b/doc/_references.md
@@ -1,0 +1,173 @@
+# [References](#references)
+
+## [Atom](#atom)
+
+<!--{"uri": "https://atom.io" }-->
+
+Atom Code Editor.
+
+## [CommonMark](#commonmark)
+
+<!--{ "uri": "https://commonmark.org" }-->
+
+Effort on providing a minimal set of standardized Markdown syntax.
+
+## [Dublin Core](#dublin-core)
+
+<!--{
+    "uri": "http://purl.org/dc/terms/",
+    "aliases": "DC, DublinCore, dc:"
+}-->
+
+The Dublin Core Metadata Initiative.
+
+## [GFM](#gfm)
+
+<!--{
+    "uri": "https://github.github.com/gfm/",
+    "aliases": "GFM, GitHub Flavoured Markdown, GitHub Flavored Markdown"
+}-->
+
+GitHub Flavoured Markdown
+
+## [github-slugger](#github-slugger)
+
+<!--{"uri": "https://npmjs.com/package/github-slugger" }-->
+
+A library providing support for [slugs🟉][1]. See github-slugger.
+
+## [glob](#glob)
+
+<!--{"uri": "https://github.com/isaacs/node-glob#glob-primer" }-->
+
+A file pattern matcher. See glob.
+
+## [glossarify-md](#glossarify-md)
+
+<!--{"uri": "https://github.com/about-code/glossarify-md" }-->
+
+This project.
+
+## [Jekyll](#jekyll)
+
+<!--{"uri": "https://jekyllrb.com" }-->
+
+A static website renderer compiling an HTML website from Markdown files.
+
+## [JSON-LD](#json-ld)
+
+<!--{
+    "uri": "https://json-ld.org",
+    "aliases": "JSON-LD Spec"
+}-->
+
+JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public [vocabularies🟉][2]. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. SKOS is one such vocabulary supported by glossarify-md
+
+## [jsonld Library](#jsonld-library)
+
+<!--{
+    "uri": "https://npmjs.com/package/jsonld",
+    "aliases": "jsonld"
+}-->
+
+A JavaScript implementation of JSON-LD.
+
+## [Linked Data](#linked-data)
+
+<!--{
+    "uri": "https://www.w3.org/standards/semanticweb/ontology",
+    "aliases": "LD"
+}-->
+
+See Linked Data.
+
+## [mdAst](#mdast)
+
+<!--{
+    "uri": "https://github.com/syntax-tree/mdast",
+    "aliases": "mdAST, mdast"
+}-->
+
+Specification and Implementation of a Markdown Abstract Syntax Tree.
+
+## [micromark](#micromark)
+
+<!--{"uri": "https://github.com/micromark/" }-->
+
+A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing).
+
+## [npm](#npm)
+
+<!-- {"uri": "https://npmjs.com"}-->
+
+Node Package Manager. See npm.
+
+## [OWL](#owl)
+
+<!--{"uri": "https://www.w3.org/TR/2012/REC-owl2-overview-20121211/" }-->
+
+Web Ontology Language.
+
+## [pandoc](#pandoc)
+
+<!--{"uri": "https://pandoc.org" }-->
+
+See pandoc.
+
+## [PlantUML](#plantuml)
+
+<!--{"uri": "https://plantuml.com" }-->
+
+Generates diagrams from text files written in the PlantUML syntax.
+
+## [remark](#remark)
+
+<!--{"uri": "https://github.com/remarkjs/remark" }-->
+
+*remark* is a parser and compiler project under the unified umbrella for *Markdown* text files in particular.
+
+## [SKOS](#skos)
+
+<!--{ "uri": "http://w3.org/skos/" }-->
+
+With the Simple [Knowledge Organization System🟉][3] (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)[vocabulary🟉][2] which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
+
+## [unified](#unified)
+
+<!--{ "uri": "https://unifiedjs.com" }-->
+
+*unified* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md][4]
+
+## [URN](#urn)
+
+<!--{ "uri": "https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml" }-->
+
+Uniform Resource Names. See URN.
+
+## [VSCode](#vscode)
+
+<!--{ "uri": "https://code.visualstudio.com" }-->
+
+[Code-OSS]: https://github.com/microsoft/vscode
+
+Visual Studio Code. See VSCode or [Code-OSS].
+
+## [vuepress](#vuepress)
+
+<!--{"uri": "https://vuepress.vuejs.org" }-->
+
+A static website generator translating markdown files into a website powered by \[vuejs].
+
+## [vuejs](#vuejs)
+
+<!--{"uri": "https://vuejs.org" }-->
+
+A Single Page Application framework written in JavaScript.
+
+[1]: ./glossary.md#slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
+
+[2]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
+
+[3]: ./glossary.md#kos---knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
+
+[4]: ./conceptual-layers.md

--- a/doc/conceptual-layers.md
+++ b/doc/conceptual-layers.md
@@ -6,30 +6,16 @@
 
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
 
-Conceptual layers of text processing by [glossarify-md⎆][1] and projects contributing to each layer
+Conceptual layers of text processing by glossarify-md and projects contributing to each layer
 
-| Layer | Project             | Conceptual purpose                                                                                                                                                                    |
-| ----- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 4     | [glossarify-md⎆][1] | cross-linking multiple markdown files                                                                                                                                                 |
-| 3     | [unified⎆][2]       | umbrella project for *text file processing in general*                                                                                                                                |
-| 2     | [remark⎆][3]        | [unified⎆][2] *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree ([mdAst⎆][4]) data structure grown from [micromark⎆][5] tokens. |
-| 1     | [micromark⎆][5]     | remarks internal markdown syntax tokenizer                                                                                                                                            |
-| 0     | [CommonMark⎆][6]    | Markdown Syntax Specification                                                                                                                                                         |
+| Layer | Project       | Conceptual purpose                                                                                                                                                  |
+| ----- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4     | glossarify-md | cross-linking multiple markdown files                                                                                                                               |
+| 3     | unified       | umbrella project for *text file processing in general*                                                                                                              |
+| 2     | remark        | unified *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree (mdAst) data structure grown from micromark tokens. |
+| 1     | micromark     | remarks internal markdown syntax tokenizer                                                                                                                          |
+| 0     | CommonMark    | Markdown Syntax Specification                                                                                                                                       |
 
-[glossarify-md⎆][1] is built on [unified⎆][2], an umbrella project for *text file processing in general*. We use unified with [remark⎆][3] which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) [micromark⎆][5] which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. micromark can be considered a technical implementation of the textual [CommonMark⎆][6] specification.
+glossarify-md is built on unified, an umbrella project for *text file processing in general*. We use unified with remark which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) micromark which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. micromark can be considered a technical implementation of the textual CommonMark specification.
 
-When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required [micromark⎆][5] extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in [glossarify-md⎆][1] already installs itself is [remark-gfm] which adds support for the popular [CommonMark⎆][6] syntax extension [GitHub Flavoured Markdown⎆][7] (tables, footnotes and more).
-
-[1]: https://github.com/about-code/glossarify-md "This project."
-
-[2]: https://unifiedjs.com "unified is an umbrella project around text file processing in general."
-
-[3]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
-
-[4]: https://github.com/syntax-tree/mdast "Specification and Implementation of a Markdown Abstract Syntax Tree."
-
-[5]: https://github.com/micromark/ "A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing)."
-
-[6]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
-
-[7]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"
+When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required micromark extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in glossarify-md already installs itself is [remark-gfm] which adds support for the popular CommonMark syntax extension GitHub Flavoured Markdown (tables, footnotes and more).

--- a/doc/conceptual-layers.md
+++ b/doc/conceptual-layers.md
@@ -6,19 +6,19 @@
 
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
 
-Conceptual layers of text processing by [glossarify-md…][1] and projects contributing to each layer
+Conceptual layers of text processing by [glossarify-md][1] and projects contributing to each layer
 
-| Layer | Project             | Conceptual purpose                                                                                                                                                                    |
-| ----- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 4     | [glossarify-md…][1] | cross-linking multiple markdown files                                                                                                                                                 |
-| 3     | [unified…][2]       | umbrella project for *text file processing in general*                                                                                                                                |
-| 2     | [remark…][3]        | [unified…][2] *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree ([mdAst…][4]) data structure grown from [micromark…][5] tokens. |
-| 1     | [micromark…][5]     | remarks internal markdown syntax tokenizer                                                                                                                                            |
-| 0     | [CommonMark…][6]    | Markdown Syntax Specification                                                                                                                                                         |
+| Layer | Project            | Conceptual purpose                                                                                                                                                                 |
+| ----- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4     | [glossarify-md][1] | cross-linking multiple markdown files                                                                                                                                              |
+| 3     | [unified][2]       | umbrella project for *text file processing in general*                                                                                                                             |
+| 2     | [remark][3]        | [unified][2] *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree ([mdAst][4]) data structure grown from [micromark][5] tokens. |
+| 1     | [micromark][5]     | remarks internal markdown syntax tokenizer                                                                                                                                         |
+| 0     | [CommonMark][6]    | Markdown Syntax Specification                                                                                                                                                      |
 
-[glossarify-md…][1] is built on [unified…][2], an umbrella project for *text file processing in general*. We use unified with [remark…][3] which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) [micromark…][5] which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. micromark can be considered a technical implementation of the textual [CommonMark…][6] specification.
+[glossarify-md][1] is built on [unified][2], an umbrella project for *text file processing in general*. We use unified with [remark][3] which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) [micromark][5] which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. micromark can be considered a technical implementation of the textual [CommonMark][6] specification.
 
-When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required [micromark…][5] extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in [glossarify-md…][1] already installs itself is [remark-gfm] which adds support for the popular [CommonMark…][6] syntax extension [GitHub Flavoured Markdown…][7] (tables, footnotes and more).
+When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required [micromark][5] extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in [glossarify-md][1] already installs itself is [remark-gfm] which adds support for the popular [CommonMark][6] syntax extension [GitHub Flavoured Markdown][7] (tables, footnotes and more).
 
 [1]: https://github.com/about-code/glossarify-md "This project."
 

--- a/doc/conceptual-layers.md
+++ b/doc/conceptual-layers.md
@@ -6,19 +6,19 @@
 
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
 
-Conceptual layers of text processing by [glossarify-md][1] and projects contributing to each layer
+Conceptual layers of text processing by [glossarify-md⎆][1] and projects contributing to each layer
 
-| Layer | Project            | Conceptual purpose                                                                                                                                                               |
-| ----- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 4     | [glossarify-md][1] | cross-linking multiple markdown files                                                                                                                                            |
-| 3     | [unified][2]       | umbrella project for *text file processing in general*                                                                                                                           |
-| 2     | [remark][3]        | [unified][2] *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree (\[mdast]) data structure grown from [micromark][4] tokens. |
-| 1     | [micromark][4]     | remarks internal markdown syntax tokenizer                                                                                                                                       |
-| 0     | [CommonMark][5]    | Markdown Syntax Specification                                                                                                                                                    |
+| Layer | Project             | Conceptual purpose                                                                                                                                                                    |
+| ----- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4     | [glossarify-md⎆][1] | cross-linking multiple markdown files                                                                                                                                                 |
+| 3     | [unified⎆][2]       | umbrella project for *text file processing in general*                                                                                                                                |
+| 2     | [remark⎆][3]        | [unified⎆][2] *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree ([mdAst⎆][4]) data structure grown from [micromark⎆][5] tokens. |
+| 1     | [micromark⎆][5]     | remarks internal markdown syntax tokenizer                                                                                                                                            |
+| 0     | [CommonMark⎆][6]    | Markdown Syntax Specification                                                                                                                                                         |
 
-[glossarify-md][1] is built on [unified][2], an umbrella project for *text file processing in general*. We use unified with [remark][3] which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) [micromark][4] which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. micromark can be considered a technical implementation of the textual [CommonMark][5] specification.
+[glossarify-md⎆][1] is built on [unified⎆][2], an umbrella project for *text file processing in general*. We use unified with [remark⎆][3] which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) [micromark⎆][5] which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. micromark can be considered a technical implementation of the textual [CommonMark⎆][6] specification.
 
-When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required [micromark][4] extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in [glossarify-md][1] already installs itself is [remark-gfm] which adds support for the popular [CommonMark][5] syntax extension [GitHub Flavoured Markdown][6] (tables, footnotes and more).
+When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required [micromark⎆][5] extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in [glossarify-md⎆][1] already installs itself is [remark-gfm] which adds support for the popular [CommonMark⎆][6] syntax extension [GitHub Flavoured Markdown⎆][7] (tables, footnotes and more).
 
 [1]: https://github.com/about-code/glossarify-md "This project."
 
@@ -26,8 +26,10 @@ When looking for non-standard [syntax extensions][doc-syntax-extensions] you sho
 
 [3]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
 
-[4]: https://github.com/micromark/ "A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing)."
+[4]: https://github.com/syntax-tree/mdast "Specification and Implementation of a Markdown Abstract Syntax Tree."
 
-[5]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+[5]: https://github.com/micromark/ "A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing)."
 
-[6]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"
+[6]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+
+[7]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"

--- a/doc/conceptual-layers.md
+++ b/doc/conceptual-layers.md
@@ -6,16 +6,30 @@
 
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
 
-Conceptual layers of text processing by glossarify-md and projects contributing to each layer
+Conceptual layers of text processing by [glossarify-md…][1] and projects contributing to each layer
 
-| Layer | Project       | Conceptual purpose                                                                                                                                                  |
-| ----- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 4     | glossarify-md | cross-linking multiple markdown files                                                                                                                               |
-| 3     | unified       | umbrella project for *text file processing in general*                                                                                                              |
-| 2     | remark        | unified *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree (mdAst) data structure grown from micromark tokens. |
-| 1     | micromark     | remarks internal markdown syntax tokenizer                                                                                                                          |
-| 0     | CommonMark    | Markdown Syntax Specification                                                                                                                                       |
+| Layer | Project             | Conceptual purpose                                                                                                                                                                    |
+| ----- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4     | [glossarify-md…][1] | cross-linking multiple markdown files                                                                                                                                                 |
+| 3     | [unified…][2]       | umbrella project for *text file processing in general*                                                                                                                                |
+| 2     | [remark…][3]        | [unified…][2] *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree ([mdAst…][4]) data structure grown from [micromark…][5] tokens. |
+| 1     | [micromark…][5]     | remarks internal markdown syntax tokenizer                                                                                                                                            |
+| 0     | [CommonMark…][6]    | Markdown Syntax Specification                                                                                                                                                         |
 
-glossarify-md is built on unified, an umbrella project for *text file processing in general*. We use unified with remark which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) micromark which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. micromark can be considered a technical implementation of the textual CommonMark specification.
+[glossarify-md…][1] is built on [unified…][2], an umbrella project for *text file processing in general*. We use unified with [remark…][3] which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) [micromark…][5] which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. micromark can be considered a technical implementation of the textual [CommonMark…][6] specification.
 
-When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required micromark extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in glossarify-md already installs itself is [remark-gfm] which adds support for the popular CommonMark syntax extension GitHub Flavoured Markdown (tables, footnotes and more).
+When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required [micromark…][5] extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in [glossarify-md…][1] already installs itself is [remark-gfm] which adds support for the popular [CommonMark…][6] syntax extension [GitHub Flavoured Markdown…][7] (tables, footnotes and more).
+
+[1]: https://github.com/about-code/glossarify-md "This project."
+
+[2]: https://unifiedjs.com "unified is an umbrella project around text file processing in general."
+
+[3]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+
+[4]: https://github.com/syntax-tree/mdast "Specification and Implementation of a Markdown Abstract Syntax Tree."
+
+[5]: https://github.com/micromark/ "A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing)."
+
+[6]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+
+[7]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"

--- a/doc/conceptual-layers.md
+++ b/doc/conceptual-layers.md
@@ -1,39 +1,33 @@
 # [Internals: Conceptual Layers](#internals-conceptual-layers)
 
-[CommonMark]: https://commonmark.org
-
 [doc-syntax-extensions]: ./markdown-syntax-extensions.md
-
-[GFM]: https://github.github.com/gfm/
-
-[glossarify-md]: https://github.com/about-code/glossarify-md
-
-[mdast]: https://github.com/syntax-tree/mdast
-
-[micromark]: https://github.com/micromark/
-
-[remark]: https://github.com/remarkjs/remark
 
 [remark-gfm]: https://npmjs.com/package/remark-gfm
 
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
 
-[unified]: https://unifiedjs.com
+Conceptual layers of text processing by [glossarify-md][1] and projects contributing to each layer
 
-Conceptual layers of text processing by [glossarify-md] and projects contributing to each layer
+| Layer | Project            | Conceptual purpose                                                                                                                                                               |
+| ----- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4     | [glossarify-md][1] | cross-linking multiple markdown files                                                                                                                                            |
+| 3     | [unified][2]       | umbrella project for *text file processing in general*                                                                                                                           |
+| 2     | [remark][3]        | [unified][2] *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree (\[mdast]) data structure grown from [micromark][4] tokens. |
+| 1     | [micromark][4]     | remarks internal markdown syntax tokenizer                                                                                                                                       |
+| 0     | [CommonMark][5]    | Markdown Syntax Specification                                                                                                                                                    |
 
-| Layer | Project         | Conceptual purpose                                                                                                                                                           |
-| ----- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 4     | [glossarify-md] | cross-linking multiple markdown files                                                                                                                                        |
-| 3     | [unified]       | umbrella project for *text file processing in general*                                                                                                                       |
-| 2     | [remark]        | [unified🟉][1] *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree ([mdast]) data structure grown from micromark tokens. |
-| 1     | [micromark]     | remarks internal markdown syntax tokenizer                                                                                                                                   |
-| 0     | [CommonMark]    | Markdown Syntax Specification                                                                                                                                                |
+[glossarify-md][1] is built on [unified][2], an umbrella project for *text file processing in general*. We use unified with [remark][3] which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) [micromark][4] which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. micromark can be considered a technical implementation of the textual [CommonMark][5] specification.
 
-[glossarify-md] is built on [unified], an umbrella project for *text file processing in general*. We use [unified🟉][1] with [remark] which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. [remark🟉][2] itself is built on (or better *wrapping around*) [micromark] which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. [micromark] can be considered a technical implementation of the textual [CommonMark] specification.
+When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required [micromark][4] extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in [glossarify-md][1] already installs itself is [remark-gfm] which adds support for the popular [CommonMark][5] syntax extension [GitHub Flavoured Markdown][6] (tables, footnotes and more).
 
-When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required [micromark] extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in [glossarify-md] already installs itself is [remark-gfm] which adds support for the popular CommonMark syntax extension [GitHub Flavoured Markdown][GFM] (tables, footnotes and more).
+[1]: https://github.com/about-code/glossarify-md "This project."
 
-[1]: ./glossary.md#unified "unified is an umbrella project around text file processing in general."
+[2]: https://unifiedjs.com "unified is an umbrella project around text file processing in general."
 
-[2]: ./glossary.md#remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+[3]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+
+[4]: https://github.com/micromark/ "A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing)."
+
+[5]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+
+[6]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -12,9 +12,9 @@ A sementically similar or equivalent alternative name for a [term🟉][4]. May a
 
 A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-md][1] as a glossary.
 
-## [Term Attributes](#term-attributes)
+## [Term Attribute](#term-attribute)
 
-<!--{ "aliases": "term attribute, term-attribute" }-->
+<!--{ "aliases": "term attributes, term-attribute" }-->
 
 [Term🟉][4] Attributes are properties passed to [glossarify-md][1] using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -1,8 +1,8 @@
 # [Glossary](#glossary)
 
-[glossarify-md][1]: [https://github.com/about-code/glossarify-md][2]
+[glossarify-md⎆][1]: [https://github.com/about-code/glossarify-md][2]
 
-This is a glossary of terms helpful when working with [glossarify-md][1] or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json][3] configuration at the root of this repo.
+This is a glossary of terms helpful when working with [glossarify-md⎆][1] or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json][3] configuration at the root of this repo.
 
 ## [Alias](#alias)
 
@@ -10,13 +10,13 @@ A sementically similar or equivalent alternative name for a [term🟉][4]. May a
 
 ## [Term](#term)
 
-A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-md][1] as a glossary.
+A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-md⎆][1] as a glossary.
 
 ## [Term Attributes](#term-attributes)
 
 <!--{ "uri": "term attribute, term-attribute" }-->
 
-[Term🟉][4] Attributes are properties passed to [glossarify-md][1] using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
+[Term🟉][4] Attributes are properties passed to [glossarify-md⎆][1] using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
 
 *glossary.md*
 
@@ -31,7 +31,7 @@ A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-m
 <!--{ "aliases": "term hint, term-hint" }-->
 
 An optional (symbol-) character like for example `🟉` decorating a [term🟉][4] link to distinguish it from a regular link.
-See [glossarify-md][1] configuration options for details.
+See [glossarify-md⎆][1] configuration options for details.
 
 ## [Vocabulary](#vocabulary)
 
@@ -69,9 +69,9 @@ The fragment is the part follwing the `#` in a [URL🟉][7].
 
 <!--{ "aliases": "KOS, Knowledge Organization System" }-->
 
-Glossaries are considered a kind of *Knowledge Organisation System ([KOS🟉][8])* which organizes knowledge as a list of terms and [term🟉][4] definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed [SKOS][9].
+Glossaries are considered a kind of *Knowledge Organisation System ([KOS🟉][8])* which organizes knowledge as a list of terms and [term🟉][4] definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed [SKOS⎆][9].
 
-[Formal Ontologies🟉][10] are graph-like [KOS🟉][8] which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the *Web Ontology Language* [OWL][11]. [SKOS][9] was built on top of OWL.
+[Formal Ontologies🟉][10] are graph-like [KOS🟉][8] which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the *Web Ontology Language* [OWL⎆][11]. [SKOS⎆][9] was built on top of OWL.
 
 [1]: https://github.com/about-code/glossarify-md "This project."
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -1,8 +1,8 @@
 # [Glossary](#glossary)
 
-[glossarify-md…][1]: [https://github.com/about-code/glossarify-md][2]
+[glossarify-md][1]: [https://github.com/about-code/glossarify-md][2]
 
-This is a glossary of terms helpful when working with [glossarify-md…][1] or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json][3] configuration at the root of this repo.
+This is a glossary of terms helpful when working with [glossarify-md][1] or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json][3] configuration at the root of this repo.
 
 ## [Alias](#alias)
 
@@ -10,13 +10,13 @@ A sementically similar or equivalent alternative name for a [term🟉][4]. May a
 
 ## [Term](#term)
 
-A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-md…][1] as a glossary.
+A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-md][1] as a glossary.
 
 ## [Term Attributes](#term-attributes)
 
-<!--{ "uri": "term attribute, term-attribute" }-->
+<!--{ "aliases": "term attribute, term-attribute" }-->
 
-[Term🟉][4] Attributes are properties passed to [glossarify-md…][1] using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
+[Term🟉][4] Attributes are properties passed to [glossarify-md][1] using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
 
 *glossary.md*
 
@@ -31,7 +31,7 @@ A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-m
 <!--{ "aliases": "term hint, term-hint" }-->
 
 An optional (symbol-) character like for example `🟉` decorating a [term🟉][4] link to distinguish it from a regular link.
-See [glossarify-md…][1] configuration options for details.
+See [glossarify-md][1] configuration options for details.
 
 ## [Vocabulary](#vocabulary)
 
@@ -69,9 +69,9 @@ The fragment is the part follwing the `#` in a [URL🟉][7].
 
 <!--{ "aliases": "KOS, Knowledge Organization System" }-->
 
-Glossaries are considered a kind of *Knowledge Organisation System ([KOS🟉][8])* which organizes knowledge as a list of terms and [term🟉][4] definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed [SKOS…][9].
+Glossaries are considered a kind of *Knowledge Organisation System ([KOS🟉][8])* which organizes knowledge as a list of terms and [term🟉][4] definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed [SKOS][9].
 
-[Formal Ontologies🟉][10] are graph-like [KOS🟉][8] which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the *Web Ontology Language* [OWL…][11]. [SKOS…][9] was built on top of OWL.
+[Formal Ontologies🟉][10] are graph-like [KOS🟉][8] which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the *Web Ontology Language* [OWL][11]. [SKOS][9] was built on top of OWL.
 
 [1]: https://github.com/about-code/glossarify-md "This project."
 

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -1,22 +1,22 @@
 # [Glossary](#glossary)
 
-glossarify-md: [https://github.com/about-code/glossarify-md][1]
+[glossarify-md…][1]: [https://github.com/about-code/glossarify-md][2]
 
-This is a glossary of terms helpful when working with glossarify-md or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json][2] configuration at the root of this repo.
+This is a glossary of terms helpful when working with [glossarify-md…][1] or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json][3] configuration at the root of this repo.
 
 ## [Alias](#alias)
 
-A sementically similar or equivalent alternative name for a [term🟉][3]. May also be used to link grammatical variants of a term with a term definition.
+A sementically similar or equivalent alternative name for a [term🟉][4]. May also be used to link grammatical variants of a term with a term definition.
 
 ## [Term](#term)
 
-A [term🟉][3] is a heading in a markdown file which is passed to glossarify-md as a glossary.
+A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-md…][1] as a glossary.
 
 ## [Term Attributes](#term-attributes)
 
 <!--{ "uri": "term attribute, term-attribute" }-->
 
-[Term🟉][3] Attributes are properties passed to glossarify-md using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
+[Term🟉][4] Attributes are properties passed to [glossarify-md…][1] using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
 
 *glossary.md*
 
@@ -30,8 +30,8 @@ A [term🟉][3] is a heading in a markdown file which is passed to glossarify-md
 
 <!--{ "aliases": "term hint, term-hint" }-->
 
-An optional (symbol-) character like for example `🟉` decorating a [term🟉][3] link to distinguish it from a regular link.
-See glossarify-md configuration options for details.
+An optional (symbol-) character like for example `🟉` decorating a [term🟉][4] link to distinguish it from a regular link.
+See [glossarify-md…][1] configuration options for details.
 
 ## [Vocabulary](#vocabulary)
 
@@ -43,7 +43,7 @@ A collection of terms which is uniquely identifiable. See also [Semantic Web Voc
 
 ## [Linkification](#linkification)
 
-Process of searching for a [term🟉][3] in *document A* matching a heading phrase in
+Process of searching for a [term🟉][4] in *document A* matching a heading phrase in
 *document B* and replacing the term in *document A* with a Markdown link pointing
 onto the term definition in *document B*.
 
@@ -51,13 +51,13 @@ onto the term definition in *document B*.
 
 <!--{ "aliases": "slug, slugs" }-->
 
-A [slug🟉][4] is a URL-friendly identifier that can be used within [URL fragments🟉][5] to address headings / sections on a page.
+A [slug🟉][5] is a URL-friendly identifier that can be used within [URL fragments🟉][6] to address headings / sections on a page.
 
 ## [URL fragment](#url-fragment)
 
 <!-- Aliases: URL fragments -->
 
-The fragment is the part follwing the `#` in a [URL🟉][6].
+The fragment is the part follwing the `#` in a [URL🟉][7].
 
 ## [URI / URL](#uri--url)
 
@@ -69,22 +69,28 @@ The fragment is the part follwing the `#` in a [URL🟉][6].
 
 <!--{ "aliases": "KOS, Knowledge Organization System" }-->
 
-Glossaries are considered a kind of *Knowledge Organisation System ([KOS🟉][7])* which organizes knowledge as a list of terms and [term🟉][3] definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed SKOS.
+Glossaries are considered a kind of *Knowledge Organisation System ([KOS🟉][8])* which organizes knowledge as a list of terms and [term🟉][4] definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed [SKOS…][9].
 
-[Formal Ontologies🟉][8] are graph-like [KOS🟉][7] which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the *Web Ontology Language* OWL. SKOS was built on top of OWL.
+[Formal Ontologies🟉][10] are graph-like [KOS🟉][8] which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the *Web Ontology Language* [OWL…][11]. [SKOS…][9] was built on top of OWL.
 
-[1]: https://github.com/about-code/glossarify-md
+[1]: https://github.com/about-code/glossarify-md "This project."
 
-[2]: ../glossarify-md.conf.json
+[2]: https://github.com/about-code/glossarify-md
 
-[3]: #term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
+[3]: ../glossarify-md.conf.json
 
-[4]: #slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
+[4]: #term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 
-[5]: #url-fragment "The fragment is the part follwing the # in a URL."
+[5]: #slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
 
-[6]: #uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+[6]: #url-fragment "The fragment is the part follwing the # in a URL."
 
-[7]: #kos---knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
+[7]: #uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[8]: #vocabulary "A collection of terms which is uniquely identifiable."
+[8]: #kos---knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
+
+[9]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
+
+[10]: #vocabulary "A collection of terms which is uniquely identifiable."
+
+[11]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/ "Web Ontology Language."

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -1,22 +1,22 @@
 # [Glossary](#glossary)
 
-[glossarify-md⎆][1]: [https://github.com/about-code/glossarify-md][2]
+glossarify-md: [https://github.com/about-code/glossarify-md][1]
 
-This is a glossary of terms helpful when working with [glossarify-md⎆][1] or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json][3] configuration at the root of this repo.
+This is a glossary of terms helpful when working with glossarify-md or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json][2] configuration at the root of this repo.
 
 ## [Alias](#alias)
 
-A sementically similar or equivalent alternative name for a [term🟉][4]. May also be used to link grammatical variants of a term with a term definition.
+A sementically similar or equivalent alternative name for a [term🟉][3]. May also be used to link grammatical variants of a term with a term definition.
 
 ## [Term](#term)
 
-A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-md⎆][1] as a glossary.
+A [term🟉][3] is a heading in a markdown file which is passed to glossarify-md as a glossary.
 
 ## [Term Attributes](#term-attributes)
 
 <!--{ "uri": "term attribute, term-attribute" }-->
 
-[Term🟉][4] Attributes are properties passed to [glossarify-md⎆][1] using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
+[Term🟉][3] Attributes are properties passed to glossarify-md using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
 
 *glossary.md*
 
@@ -30,8 +30,8 @@ A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-m
 
 <!--{ "aliases": "term hint, term-hint" }-->
 
-An optional (symbol-) character like for example `🟉` decorating a [term🟉][4] link to distinguish it from a regular link.
-See [glossarify-md⎆][1] configuration options for details.
+An optional (symbol-) character like for example `🟉` decorating a [term🟉][3] link to distinguish it from a regular link.
+See glossarify-md configuration options for details.
 
 ## [Vocabulary](#vocabulary)
 
@@ -43,7 +43,7 @@ A collection of terms which is uniquely identifiable. See also [Semantic Web Voc
 
 ## [Linkification](#linkification)
 
-Process of searching for a [term🟉][4] in *document A* matching a heading phrase in
+Process of searching for a [term🟉][3] in *document A* matching a heading phrase in
 *document B* and replacing the term in *document A* with a Markdown link pointing
 onto the term definition in *document B*.
 
@@ -51,13 +51,13 @@ onto the term definition in *document B*.
 
 <!--{ "aliases": "slug, slugs" }-->
 
-A [slug🟉][5] is a URL-friendly identifier that can be used within [URL fragments🟉][6] to address headings / sections on a page.
+A [slug🟉][4] is a URL-friendly identifier that can be used within [URL fragments🟉][5] to address headings / sections on a page.
 
 ## [URL fragment](#url-fragment)
 
 <!-- Aliases: URL fragments -->
 
-The fragment is the part follwing the `#` in a [URL🟉][7].
+The fragment is the part follwing the `#` in a [URL🟉][6].
 
 ## [URI / URL](#uri--url)
 
@@ -69,28 +69,22 @@ The fragment is the part follwing the `#` in a [URL🟉][7].
 
 <!--{ "aliases": "KOS, Knowledge Organization System" }-->
 
-Glossaries are considered a kind of *Knowledge Organisation System ([KOS🟉][8])* which organizes knowledge as a list of terms and [term🟉][4] definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed [SKOS⎆][9].
+Glossaries are considered a kind of *Knowledge Organisation System ([KOS🟉][7])* which organizes knowledge as a list of terms and [term🟉][3] definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed SKOS.
 
-[Formal Ontologies🟉][10] are graph-like [KOS🟉][8] which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the *Web Ontology Language* [OWL⎆][11]. [SKOS⎆][9] was built on top of OWL.
+[Formal Ontologies🟉][8] are graph-like [KOS🟉][7] which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the *Web Ontology Language* OWL. SKOS was built on top of OWL.
 
-[1]: https://github.com/about-code/glossarify-md "This project."
+[1]: https://github.com/about-code/glossarify-md
 
-[2]: https://github.com/about-code/glossarify-md
+[2]: ../glossarify-md.conf.json
 
-[3]: ../glossarify-md.conf.json
+[3]: #term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 
-[4]: #term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
+[4]: #slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
 
-[5]: #slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
+[5]: #url-fragment "The fragment is the part follwing the # in a URL."
 
-[6]: #url-fragment "The fragment is the part follwing the # in a URL."
+[6]: #uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[7]: #uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+[7]: #kos---knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
 
-[8]: #kos---knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
-
-[9]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
-
-[10]: #vocabulary "A collection of terms which is uniquely identifiable."
-
-[11]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/ "Web Ontology Language."
+[8]: #vocabulary "A collection of terms which is uniquely identifiable."

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -1,60 +1,22 @@
-# [Glossary of glossarify-md](#glossary-of-glossarify-md)
+# [Glossary](#glossary)
 
-[glossarify-md]: https://github.com/about-code/glossarify-md
+[glossarify-md][1]: [https://github.com/about-code/glossarify-md][2]
 
-This is a glossary of terms helpful when working with glossarify-md or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json][1] configuration at the root of this repo.
+This is a glossary of terms helpful when working with [glossarify-md][1] or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json][3] configuration at the root of this repo.
 
-## [JSON-LD](#json-ld)
+## [Alias](#alias)
 
-[JSON-LD]: https://json-ld.org
+A sementically similar or equivalent alternative name for a [term🟉][4]. May also be used to link grammatical variants of a term with a term definition.
 
-[jsonld]: https://npmjs.com/package/jsonld
+## [Term](#term)
 
-[LD]: https://www.w3.org/standards/semanticweb/ontology
-
-[JSON-LD] is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies. With [JSON-LD🟉][2] it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. [SKOS🟉][3] is one such vocabulary supported by [glossarify-md]
-
-## [KOS (Knowledge Organization Systems)](#kos-knowledge-organization-systems)
-
-<!--{ "aliases": "KOS, Knowledge Organization System" }-->
-
-[vocabularies]: https://www.w3.org/standards/semanticweb/ontology
-
-[OWL]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/
-
-Glossaries are considered a kind of *Knowledge Organisation System ([KOS🟉][4])* which organizes knowledge as a list of terms and term definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed [SKOS🟉][3].
-
-[Formal Ontologies][vocabularies] are graph-like [KOS🟉][4] which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the [*Web Ontology Language* OWL][OWL]. [SKOS🟉][3] was built on top of OWL.
-
-## [Linkification](#linkification)
-
-Process of searching for a term in *document A* matching a heading phrase in
-*document B* and replacing the term in *document A* with a Markdown link pointing
-onto the term definition in *document B*.
-
-## [remark](#remark)
-
-[remark]: https://github.com/remarkjs/remark
-
-[remark] is a parser and compiler project under the [unified🟉][5] umbrella for *Markdown* text files in particular.
-
-## [SKOS](#skos)
-
-[SKOS]: http://w3.org/skos/
-
-With [SKOS][6] the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
-
-## [slug](#slug)
-
-<!--{ "aliases": "slugs" }-->
-
-A [slug🟉][7] by our definition is a URL-friendly identifier created from arbitrary text that can be used within [URL fragments🟉][8] to address headings / sections on a page.
+A [term🟉][4] is a heading in a markdown file which is passed to [glossarify-md][1] as a glossary.
 
 ## [Term Attributes](#term-attributes)
 
 <!--{ "uri": "term attribute, term-attribute" }-->
 
-[Term Attributes🟉][9] are properties passed to glossarify-md using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
+[Term🟉][4] Attributes are properties passed to [glossarify-md][1] using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
 
 *glossary.md*
 
@@ -68,20 +30,34 @@ A [slug🟉][7] by our definition is a URL-friendly identifier created from arbi
 
 <!--{ "aliases": "term hint, term-hint" }-->
 
-An optional (symbol-) character like for example `🟉` decorating a term link to distinguish it from a regular link.
-See glossarify-md configuration options for details.
+An optional (symbol-) character like for example `🟉` decorating a [term🟉][4] link to distinguish it from a regular link.
+See [glossarify-md][1] configuration options for details.
 
-## [unified](#unified)
+## [Vocabulary](#vocabulary)
 
-[unified]: https://unifiedjs.com
+<!--{ "aliases": "vocabularies, Formal Ontologies" }-->
 
-[unified] is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md][10]
+[vocabularies]: https://www.w3.org/standards/semanticweb/ontology
+
+A collection of terms which is uniquely identifiable. See also [Semantic Web Vocabularies and Ontologies][vocabularies].
+
+## [Linkification](#linkification)
+
+Process of searching for a [term🟉][4] in *document A* matching a heading phrase in
+*document B* and replacing the term in *document A* with a Markdown link pointing
+onto the term definition in *document B*.
+
+## [Slug](#slug)
+
+<!--{ "aliases": "slug, slugs" }-->
+
+A [slug🟉][5] is a URL-friendly identifier that can be used within [URL fragments🟉][6] to address headings / sections on a page.
 
 ## [URL fragment](#url-fragment)
 
 <!-- Aliases: URL fragments -->
 
-The fragment is the part follwing the `#` in a [URL🟉][11].
+The fragment is the part follwing the `#` in a [URL🟉][7].
 
 ## [URI / URL](#uri--url)
 
@@ -89,48 +65,32 @@ The fragment is the part follwing the `#` in a [URL🟉][11].
 
 *Uniform Resource Identifier* and *Uniform Resource Locator* are both the same thing, which is an ID with a syntax `scheme://authority.tld/path/#fragment?query` like `https://my.org/foo/#bar?q=123`. Although both things are the same, the two acronyms are often used to emphasize whether using the ID to primarily *identify* something or using *the same ID* to *also* locate and retrieve a represention of what it identifies.
 
-<!--
-For example there's no strict requirement that URIs must resolve to a web page. They are just IDs. However URIs *can* be used to *locate and retrieve* a textual representation *of what they identify* which is when they are often called URL. A *representation* can be a web page. But an URI could als identify a technical device and could be used as an URL to locate a representation of that device in form of a datasheet.
+## [KOS - Knowledge Organization Systems](#kos---knowledge-organization-systems)
 
-URIs continue to be IDs after a particular representation like the datasheet disappears. This sometimes leads to controversies on whether a certain URL which is also an URI can ever be "reused" to locate something different than what the URI identified.
+<!--{ "aliases": "KOS, Knowledge Organization System" }-->
 
-Strictly spoken: it *should not* because URLs and URIs *are equivalent* and two sides of the same coin. A URL should be reserved to locate and serve a representation of what itself *being a URI* identifies. If it doesn't it no longer identifies *a single* thing but two different things and loses its purpose as *identifier*.
+Glossaries are considered a kind of *Knowledge Organisation System ([KOS🟉][8])* which organizes knowledge as a list of terms and [term🟉][4] definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed [SKOS][9].
 
-However, it is a matter of fact that URLs and the web page content they identify and locate change thousands of times every day world wide. Because often it simply doesn't matter *what exactly* an URI/URL identifies but just that it identifies and locates *something*. Therefore you may only really care about "durability" of an URI/URL if your audience cares or if you really want to identify a particular thing.
+[Formal Ontologies🟉][10] are graph-like [KOS🟉][8] which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the *Web Ontology Language* [OWL][11]. [SKOS][9] was built on top of OWL.
 
-If you're afraid of making a long-term comittment on a particular URI because you "might want to reuse the URL", then there's a simple solution: just add additional elements like "time", "randomness" or "uniqueness" to the URI/URL's `/path/...` or `#fragment` part to make it *unlikely* of being reused for something else.
+[1]: https://github.com/about-code/glossarify-md "This project."
 
-In case of glossarify-md you could use one of the cryptographic heading ID algorithms like `md5` or `sha256` supported by [`headingIdAlgorithm`][headingIdAlgorithm].
+[2]: https://github.com/about-code/glossarify-md
 
-[headingIdAlgorithm]: ../README.md#linkingheadingidalgorithm
--->
+[3]: ../glossarify-md.conf.json
 
-## [vuepress](#vuepress)
+[4]: #term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 
-[vuepress]: https://vuepress.vuejs.org
+[5]: #slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
 
-[vuejs]: https://vuejs.org
+[6]: #url-fragment "The fragment is the part follwing the # in a URL."
 
-[vuepress] is a static website generator translating markdown files into a website powered by [vuejs].
+[7]: #uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[1]: ../glossarify-md.conf.json
+[8]: #kos---knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
 
-[2]: #json-ld "JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies."
+[9]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
 
-[3]: #skos "With SKOS the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
+[10]: #vocabulary "A collection of terms which is uniquely identifiable."
 
-[4]: #kos-knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
-
-[5]: #unified "unified is an umbrella project around text file processing in general."
-
-[6]: https://w3.org/skos
-
-[7]: #slug "A slug by our definition is a URL-friendly identifier created from arbitrary text that can be used within URL fragments to address headings / sections on a page."
-
-[8]: #url-fragment "The fragment is the part follwing the # in a URL."
-
-[9]: #term-attributes "Term Attributes are properties passed to glossarify-md using an HTML comment syntax <!--{...}--> which encodes a JSON string: glossary.md"
-
-[10]: ./conceptual-layers.md
-
-[11]: #uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+[11]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/ "Web Ontology Language."

--- a/doc/lists-on-github.md
+++ b/doc/lists-on-github.md
@@ -30,10 +30,16 @@ Normally, when converting such markdown to HTML using a Markdown-to-HTML static 
 
 On a GitHub repository, though, you'll find that you can navigate within the repository using the list item link in `list.md` but the browser *won't* scroll to the item position `#mylist-foo` in `page.md`. The reason for this is that GitHub *[sanitizes][gfm-sanitize]* Markdown files before rendering them within their own repository previews. They allow only a small subset of HTML and strip elements like `<cite>` and other [Semantic HTML Tags][html-sem-tags] including the element's `id="#mylist-foo"` which a browser needs to be able to scroll to that part of an HTML document. Therefore, if you care for navigability in GitHub repositories, just use supported elements like `<span>` or `<a>` instead.
 
-**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in glossarify-md. For example, if you were rendering `list.md` and `page.md` with a static website generator like Jekyll or vuepress things work just fine.
+**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in [glossarify-md…][3]. For example, if you were rendering `list.md` and `page.md` with a static website generator like [Jekyll…][4] or [vuepress…][5] things work just fine.
 
-You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to [https://yoursite.github.io][3] using Jekyll.
+You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to [https://yoursite.github.io][6] using [Jekyll…][4].
 
 [1]: #my-list
 
-[3]: https://yoursite.github.io
+[3]: https://github.com/about-code/glossarify-md "This project."
+
+[4]: https://jekyllrb.com "A static website renderer compiling an HTML website from Markdown files."
+
+[5]: https://vuepress.vuejs.org "A static website generator translating markdown files into a website powered by [vuejs]."
+
+[6]: https://yoursite.github.io

--- a/doc/lists-on-github.md
+++ b/doc/lists-on-github.md
@@ -30,16 +30,10 @@ Normally, when converting such markdown to HTML using a Markdown-to-HTML static 
 
 On a GitHub repository, though, you'll find that you can navigate within the repository using the list item link in `list.md` but the browser *won't* scroll to the item position `#mylist-foo` in `page.md`. The reason for this is that GitHub *[sanitizes][gfm-sanitize]* Markdown files before rendering them within their own repository previews. They allow only a small subset of HTML and strip elements like `<cite>` and other [Semantic HTML Tags][html-sem-tags] including the element's `id="#mylist-foo"` which a browser needs to be able to scroll to that part of an HTML document. Therefore, if you care for navigability in GitHub repositories, just use supported elements like `<span>` or `<a>` instead.
 
-**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in [glossarify-md⎆][3]. For example, if you were rendering `list.md` and `page.md` with a static website generator like [Jekyll⎆][4] or [vuepress⎆][5] things work just fine.
+**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in glossarify-md. For example, if you were rendering `list.md` and `page.md` with a static website generator like Jekyll or vuepress things work just fine.
 
-You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to [https://yoursite.github.io][6] using [Jekyll⎆][4].
+You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to [https://yoursite.github.io][3] using Jekyll.
 
 [1]: #my-list
 
-[3]: https://github.com/about-code/glossarify-md "This project."
-
-[4]: https://jekyllrb.com "A static website renderer compiling an HTML website from Markdown files."
-
-[5]: https://vuepress.vuejs.org "A static website generator translating markdown files into a website powered by [vuejs]."
-
-[6]: https://yoursite.github.io
+[3]: https://yoursite.github.io

--- a/doc/lists-on-github.md
+++ b/doc/lists-on-github.md
@@ -30,9 +30,9 @@ Normally, when converting such markdown to HTML using a Markdown-to-HTML static 
 
 On a GitHub repository, though, you'll find that you can navigate within the repository using the list item link in `list.md` but the browser *won't* scroll to the item position `#mylist-foo` in `page.md`. The reason for this is that GitHub *[sanitizes][gfm-sanitize]* Markdown files before rendering them within their own repository previews. They allow only a small subset of HTML and strip elements like `<cite>` and other [Semantic HTML Tags][html-sem-tags] including the element's `id="#mylist-foo"` which a browser needs to be able to scroll to that part of an HTML document. Therefore, if you care for navigability in GitHub repositories, just use supported elements like `<span>` or `<a>` instead.
 
-**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in [glossarify-md][3]. For example, if you were rendering `list.md` and `page.md` with a static website generator like [Jekyll][4] or [vuepress][5] things work just fine.
+**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in [glossarify-md⎆][3]. For example, if you were rendering `list.md` and `page.md` with a static website generator like [Jekyll⎆][4] or [vuepress⎆][5] things work just fine.
 
-You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to [https://yoursite.github.io][6] using [Jekyll][4].
+You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to [https://yoursite.github.io][6] using [Jekyll⎆][4].
 
 [1]: #my-list
 

--- a/doc/lists-on-github.md
+++ b/doc/lists-on-github.md
@@ -30,9 +30,9 @@ Normally, when converting such markdown to HTML using a Markdown-to-HTML static 
 
 On a GitHub repository, though, you'll find that you can navigate within the repository using the list item link in `list.md` but the browser *won't* scroll to the item position `#mylist-foo` in `page.md`. The reason for this is that GitHub *[sanitizes][gfm-sanitize]* Markdown files before rendering them within their own repository previews. They allow only a small subset of HTML and strip elements like `<cite>` and other [Semantic HTML Tags][html-sem-tags] including the element's `id="#mylist-foo"` which a browser needs to be able to scroll to that part of an HTML document. Therefore, if you care for navigability in GitHub repositories, just use supported elements like `<span>` or `<a>` instead.
 
-**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in [glossarify-md…][3]. For example, if you were rendering `list.md` and `page.md` with a static website generator like [Jekyll…][4] or [vuepress…][5] things work just fine.
+**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in [glossarify-md][3]. For example, if you were rendering `list.md` and `page.md` with a static website generator like [Jekyll][4] or [vuepress][5] things work just fine.
 
-You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to [https://yoursite.github.io][6] using [Jekyll…][4].
+You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to [https://yoursite.github.io][6] using [Jekyll][4].
 
 [1]: #my-list
 

--- a/doc/lists-on-github.md
+++ b/doc/lists-on-github.md
@@ -2,17 +2,11 @@
 
 [doc-readme-lists]: ../README.md#lists
 
-[glossarify-md]: https://github.com/about-code/glossarify-md
-
 [gfm-sanitize]: https://github.github.com/gfm/#what-is-github-flavored-markdown-
 
 [gh-pages]: https://pages.github.com/
 
 [html-sem-tags]: https://www.w3schools.com/html/html5_semantic_elements
-
-[Jekyll]: https://jekyllrb.com
-
-[vuepress]: https://vuepress.vuejs.org
 
 [2]: <>
 
@@ -36,10 +30,16 @@ Normally, when converting such markdown to HTML using a Markdown-to-HTML static 
 
 On a GitHub repository, though, you'll find that you can navigate within the repository using the list item link in `list.md` but the browser *won't* scroll to the item position `#mylist-foo` in `page.md`. The reason for this is that GitHub *[sanitizes][gfm-sanitize]* Markdown files before rendering them within their own repository previews. They allow only a small subset of HTML and strip elements like `<cite>` and other [Semantic HTML Tags][html-sem-tags] including the element's `id="#mylist-foo"` which a browser needs to be able to scroll to that part of an HTML document. Therefore, if you care for navigability in GitHub repositories, just use supported elements like `<span>` or `<a>` instead.
 
-**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in [glossarify-md]. For example, if you were rendering `list.md` and `page.md` with a static website generator like [Jekyll] or [vuepress] things work just fine.
+**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in [glossarify-md][3]. For example, if you were rendering `list.md` and `page.md` with a static website generator like [Jekyll][4] or [vuepress][5] things work just fine.
 
-You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to [https://yoursite.github.io][3] using [Jekyll].
+You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to [https://yoursite.github.io][6] using [Jekyll][4].
 
 [1]: #my-list
 
-[3]: https://yoursite.github.io
+[3]: https://github.com/about-code/glossarify-md "This project."
+
+[4]: https://jekyllrb.com "A static website renderer compiling an HTML website from Markdown files."
+
+[5]: https://vuepress.vuejs.org "A static website generator translating markdown files into a website powered by [vuejs]."
+
+[6]: https://yoursite.github.io

--- a/doc/markdown-syntax-extensions.md
+++ b/doc/markdown-syntax-extensions.md
@@ -10,7 +10,7 @@
 
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
-[glossarify-md⎆][1] supports [CommonMark⎆][2] and [GitHub Flavoured Markdown⎆][3] (GFM). Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's Abstract Syntax Tree ([mdAst⎆][4]). As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
+glossarify-md supports CommonMark and GitHub Flavoured Markdown (GFM). Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's Abstract Syntax Tree (mdAst). As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
 
 *Frontmatter Syntax*
 
@@ -18,16 +18,6 @@
     key: This is a frontmatter
     ---
 
-Without special support for it [CommonMark⎆][2] compliant parsers like our [remark⎆][5] parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
+Without special support for it CommonMark compliant parsers like our remark parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
 
-**Since v5.0.0** we have opened [glossarify-md⎆][1] to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].
-
-[1]: https://github.com/about-code/glossarify-md "This project."
-
-[2]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
-
-[3]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"
-
-[4]: https://github.com/syntax-tree/mdast "Specification and Implementation of a Markdown Abstract Syntax Tree."
-
-[5]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+**Since v5.0.0** we have opened glossarify-md to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].

--- a/doc/markdown-syntax-extensions.md
+++ b/doc/markdown-syntax-extensions.md
@@ -10,7 +10,7 @@
 
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
-[glossarify-md…][1] supports [CommonMark…][2] and [GitHub Flavoured Markdown…][3] (GFM). Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's Abstract Syntax Tree ([mdAst…][4]). As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
+[glossarify-md][1] supports [CommonMark][2] and [GitHub Flavoured Markdown][3] (GFM). Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's Abstract Syntax Tree ([mdAst][4]). As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
 
 *Frontmatter Syntax*
 
@@ -18,9 +18,9 @@
     key: This is a frontmatter
     ---
 
-Without special support for it [CommonMark…][2] compliant parsers like our [remark…][5] parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
+Without special support for it [CommonMark][2] compliant parsers like our [remark][5] parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
 
-**Since v5.0.0** we have opened [glossarify-md…][1] to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].
+**Since v5.0.0** we have opened [glossarify-md][1] to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].
 
 [1]: https://github.com/about-code/glossarify-md "This project."
 

--- a/doc/markdown-syntax-extensions.md
+++ b/doc/markdown-syntax-extensions.md
@@ -10,9 +10,7 @@
 
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
-[vuepress][1]: [https://vuepress.vuejs.org][2]
-
-[glossarify-md][3] supports [CommonMark][4] and \[[GitHub Flavoured Markdown][5] (GFM)]\[GFM]. Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's \[Abstract Syntax Tree]\[mdast]. As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
+[glossarify-md⎆][1] supports [CommonMark⎆][2] and [GitHub Flavoured Markdown⎆][3] (GFM). Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's Abstract Syntax Tree ([mdAst⎆][4]). As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
 
 *Frontmatter Syntax*
 
@@ -20,18 +18,16 @@
     key: This is a frontmatter
     ---
 
-Without special support for it [CommonMark][4] compliant parsers like our [remark][6] parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
+Without special support for it [CommonMark⎆][2] compliant parsers like our [remark⎆][5] parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
 
-**Since v5.0.0** we have opened [glossarify-md][3] to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].
+**Since v5.0.0** we have opened [glossarify-md⎆][1] to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].
 
-[1]: https://vuepress.vuejs.org "A static website generator translating markdown files into a website powered by [vuejs]."
+[1]: https://github.com/about-code/glossarify-md "This project."
 
-[2]: https://vuepress.vuejs.org
+[2]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
 
-[3]: https://github.com/about-code/glossarify-md "This project."
+[3]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"
 
-[4]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+[4]: https://github.com/syntax-tree/mdast "Specification and Implementation of a Markdown Abstract Syntax Tree."
 
-[5]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"
-
-[6]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+[5]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."

--- a/doc/markdown-syntax-extensions.md
+++ b/doc/markdown-syntax-extensions.md
@@ -4,29 +4,15 @@
 
 [doc-plugins]: ./plugins.md
 
-[CommonMark]: https://www.commonmark.org
-
-[GFM]: https://github.github.com/gfm/
-
-[glossarify-md]: https://github.com/about-code/glossarify-md
-
-[mdast]: https://github.com/syntax-tree/mdast
-
-[micromark]: https://github.com/micromark/
-
-[remark]: https://github.com/remarkjs/remark
-
 [remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
 
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
 
-[unified]: https://unifiedjs.com
-
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
-[vuepress]: https://vuepress.vuejs.org
+[vuepress][1]: [https://vuepress.vuejs.org][2]
 
-[glossarify-md] supports [CommonMark] and [GitHub Flavoured Markdown (GFM)][GFM]. Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's [Abstract Syntax Tree][mdast]. As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
+[glossarify-md][3] supports [CommonMark][4] and \[[GitHub Flavoured Markdown][5] (GFM)]\[GFM]. Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's \[Abstract Syntax Tree]\[mdast]. As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
 
 *Frontmatter Syntax*
 
@@ -34,6 +20,18 @@
     key: This is a frontmatter
     ---
 
-Without special support for it [CommonMark] compliant parsers like our [remark] parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
+Without special support for it [CommonMark][4] compliant parsers like our [remark][6] parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
 
-**Since v5.0.0** we have opened [glossarify-md] to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].
+**Since v5.0.0** we have opened [glossarify-md][3] to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].
+
+[1]: https://vuepress.vuejs.org "A static website generator translating markdown files into a website powered by [vuejs]."
+
+[2]: https://vuepress.vuejs.org
+
+[3]: https://github.com/about-code/glossarify-md "This project."
+
+[4]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+
+[5]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"
+
+[6]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."

--- a/doc/markdown-syntax-extensions.md
+++ b/doc/markdown-syntax-extensions.md
@@ -10,7 +10,7 @@
 
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
-glossarify-md supports CommonMark and GitHub Flavoured Markdown (GFM). Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's Abstract Syntax Tree (mdAst). As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
+[glossarify-md…][1] supports [CommonMark…][2] and [GitHub Flavoured Markdown…][3] (GFM). Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's Abstract Syntax Tree ([mdAst…][4]). As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
 
 *Frontmatter Syntax*
 
@@ -18,6 +18,16 @@ glossarify-md supports CommonMark and GitHub Flavoured Markdown (GFM). Syntax no
     key: This is a frontmatter
     ---
 
-Without special support for it CommonMark compliant parsers like our remark parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
+Without special support for it [CommonMark…][2] compliant parsers like our [remark…][5] parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
 
-**Since v5.0.0** we have opened glossarify-md to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].
+**Since v5.0.0** we have opened [glossarify-md…][1] to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].
+
+[1]: https://github.com/about-code/glossarify-md "This project."
+
+[2]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+
+[3]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"
+
+[4]: https://github.com/syntax-tree/mdast "Specification and Implementation of a Markdown Abstract Syntax Tree."
+
+[5]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."

--- a/doc/pandoc.md
+++ b/doc/pandoc.md
@@ -14,7 +14,7 @@
 
 ## [Configure glossarify-md](#configure-glossarify-md)
 
-*[glossarify-md⎆][1].conf.json*
+*glossarify-md.conf.json*
 
 ```json
 {
@@ -32,13 +32,13 @@
 }
 ```
 
-When [pandoc⎆][2] merges multiple files into a single file we need to take care for
+When pandoc merges multiple files into a single file we need to take care for
 link stability and paths.
 
 1.  `linking.paths: "none"` disables the use of paths and uses heading ids
     (anchors), only
 2.  `headingIdPandoc: true` adds pandoc-style `{# foo}` attributes taken by
-    [pandoc⎆][2] for its own linking
+    pandoc for its own linking
 3.  `headingIdAlgorithm: "md5"` generates a heading ID based on a hashsum which is
     unique accross the file set and therefore within a pandoc-merged file, too. Other
     values may be `md5-7, sha256, sha256-7`.
@@ -54,7 +54,3 @@ Optional
 After having set these options, files can be merged, e.g. with
 
     pandoc --from=markdown -o out.html ./docs-glossarified/**/*.md
-
-[1]: https://github.com/about-code/glossarify-md "This project."
-
-[2]: https://pandoc.org "See pandoc."

--- a/doc/pandoc.md
+++ b/doc/pandoc.md
@@ -14,7 +14,7 @@
 
 ## [Configure glossarify-md](#configure-glossarify-md)
 
-*[glossarify-md…][1].conf.json*
+*[glossarify-md][1].conf.json*
 
 ```json
 {
@@ -32,13 +32,13 @@
 }
 ```
 
-When [pandoc…][2] merges multiple files into a single file we need to take care for
+When [pandoc][2] merges multiple files into a single file we need to take care for
 link stability and paths.
 
 1.  `linking.paths: "none"` disables the use of paths and uses heading ids
     (anchors), only
 2.  `headingIdPandoc: true` adds pandoc-style `{# foo}` attributes taken by
-    [pandoc…][2] for its own linking
+    [pandoc][2] for its own linking
 3.  `headingIdAlgorithm: "md5"` generates a heading ID based on a hashsum which is
     unique accross the file set and therefore within a pandoc-merged file, too. Other
     values may be `md5-7, sha256, sha256-7`.

--- a/doc/pandoc.md
+++ b/doc/pandoc.md
@@ -14,7 +14,7 @@
 
 ## [Configure glossarify-md](#configure-glossarify-md)
 
-*glossarify-md.conf.json*
+*[glossarify-md…][1].conf.json*
 
 ```json
 {
@@ -32,13 +32,13 @@
 }
 ```
 
-When pandoc merges multiple files into a single file we need to take care for
+When [pandoc…][2] merges multiple files into a single file we need to take care for
 link stability and paths.
 
 1.  `linking.paths: "none"` disables the use of paths and uses heading ids
     (anchors), only
 2.  `headingIdPandoc: true` adds pandoc-style `{# foo}` attributes taken by
-    pandoc for its own linking
+    [pandoc…][2] for its own linking
 3.  `headingIdAlgorithm: "md5"` generates a heading ID based on a hashsum which is
     unique accross the file set and therefore within a pandoc-merged file, too. Other
     values may be `md5-7, sha256, sha256-7`.
@@ -54,3 +54,7 @@ Optional
 After having set these options, files can be merged, e.g. with
 
     pandoc --from=markdown -o out.html ./docs-glossarified/**/*.md
+
+[1]: https://github.com/about-code/glossarify-md "This project."
+
+[2]: https://pandoc.org "See pandoc."

--- a/doc/pandoc.md
+++ b/doc/pandoc.md
@@ -1,7 +1,5 @@
 # [Using glossarify-md with pandoc](#using-glossarify-md-with-pandoc)
 
-[pandoc]: https://pandoc.org
-
     ${root}
        +- docs/
        +- docs-glossarified/           (Generated)
@@ -16,7 +14,7 @@
 
 ## [Configure glossarify-md](#configure-glossarify-md)
 
-*glossarify-md.conf.json*
+*[glossarify-md][1].conf.json*
 
 ```json
 {
@@ -34,13 +32,13 @@
 }
 ```
 
-When [pandoc] merges multiple files into a single file we need to take care for
+When [pandoc][2] merges multiple files into a single file we need to take care for
 link stability and paths.
 
 1.  `linking.paths: "none"` disables the use of paths and uses heading ids
     (anchors), only
 2.  `headingIdPandoc: true` adds pandoc-style `{# foo}` attributes taken by
-    pandoc for its own linking
+    [pandoc][2] for its own linking
 3.  `headingIdAlgorithm: "md5"` generates a heading ID based on a hashsum which is
     unique accross the file set and therefore within a pandoc-merged file, too. Other
     values may be `md5-7, sha256, sha256-7`.
@@ -56,3 +54,7 @@ Optional
 After having set these options, files can be merged, e.g. with
 
     pandoc --from=markdown -o out.html ./docs-glossarified/**/*.md
+
+[1]: https://github.com/about-code/glossarify-md "This project."
+
+[2]: https://pandoc.org "See pandoc."

--- a/doc/pandoc.md
+++ b/doc/pandoc.md
@@ -14,7 +14,7 @@
 
 ## [Configure glossarify-md](#configure-glossarify-md)
 
-*[glossarify-md][1].conf.json*
+*[glossarify-md⎆][1].conf.json*
 
 ```json
 {
@@ -32,13 +32,13 @@
 }
 ```
 
-When [pandoc][2] merges multiple files into a single file we need to take care for
+When [pandoc⎆][2] merges multiple files into a single file we need to take care for
 link stability and paths.
 
 1.  `linking.paths: "none"` disables the use of paths and uses heading ids
     (anchors), only
 2.  `headingIdPandoc: true` adds pandoc-style `{# foo}` attributes taken by
-    [pandoc][2] for its own linking
+    [pandoc⎆][2] for its own linking
 3.  `headingIdAlgorithm: "md5"` generates a heading ID based on a hashsum which is
     unique accross the file set and therefore within a pandoc-merged file, too. Other
     values may be `md5-7, sha256, sha256-7`.

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -12,7 +12,7 @@
 
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
-The following example demonstrates how to install a [remark plug-in][remark-plugin]. The plug-in will extend [glossarify-md…][1]'s markdown parser [remark…][2]  with support for *Frontmatter* syntax.
+The following example demonstrates how to install a [remark plug-in][remark-plugin]. The plug-in will extend [glossarify-md][1]'s markdown parser [remark][2]  with support for *Frontmatter* syntax.
 
 > **☛ Note:** glossarify-md does not guarantee compatibility with plug-ins and likely won't help with issues arising due to installing and using additional third-party plug-ins.
 
@@ -43,9 +43,9 @@ We'll assume the following file structure:
 
     npm install remark-frontmatter
 
-**3:** Make [remark…][2] load the plug-in by adding to your `remark.conf.json`:
+**3:** Make [remark][2] load the plug-in by adding to your `remark.conf.json`:
 
-*[remark…][2].conf.js*
+*[remark][2].conf.js*
 
 ```json
 {
@@ -58,10 +58,10 @@ We'll assume the following file structure:
 }
 ```
 
-1.  `remark-frontmatter` must be the name of the [npm…][3] package you installed before
+1.  `remark-frontmatter` must be the name of the [npm][3] package you installed before
 2.  any properties of the `remark-frontmatter` object are options specific to the plug-in.
 
-`remark.conf.json` follows the [unified configuration][unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *[glossarify-md…][1]*'s config schema.
+`remark.conf.json` follows the [unified configuration][unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *[glossarify-md][1]*'s config schema.
 
 > **ⓘ remark, unified, uhh... ?**
 >
@@ -69,9 +69,9 @@ We'll assume the following file structure:
 
 ## [Writing a Plug-In](#writing-a-plug-in)
 
-Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this [remark discussion and little ASCII-art][remark-discussion] helpful. Have a look at [micromark…][4] and [remark…][2] for a reference, though.
+Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this [remark discussion and little ASCII-art][remark-discussion] helpful. Have a look at [micromark][4] and [remark][2] for a reference, though.
 
-A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree (\[mdAST]\[mdast]). [glossarify-md…][1] itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
+A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree (\[mdAST]\[mdast]). [glossarify-md][1] itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
 
 A tree plug-in is a function which returns a callback that when called get's passed an \[mdAST]:
 
@@ -93,11 +93,11 @@ export default function myPlugin(options = {}) {
 }
 ```
 
-The example uses a [visit][mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's [URL🟉][5] and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of [CommonMark…][6] node types see \[mdAST].
+The example uses a [visit][mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's [URL🟉][5] and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of [CommonMark][6] node types see \[mdAST].
 
-Here's how you can set up a plug-in project next to a [glossarify-md…][1] project:
+Here's how you can set up a plug-in project next to a [glossarify-md][1] project:
 
-1.  Make a new directory *remark-my-plugin* and initialize it as an [npm…][3] package.
+1.  Make a new directory *remark-my-plugin* and initialize it as an [npm][3] package.
 
         mkdir ./remark-my-plugin
         cd ./remark-my-plugin
@@ -110,11 +110,11 @@ Here's how you can set up a plug-in project next to a [glossarify-md…][1] proj
 
 3.  Copy the JavaScript code sample above into `index.js`
 
-4.  Install the [npm…][3] dependency required by the code sample
+4.  Install the [npm][3] dependency required by the code sample
 
         npm install unist-util-visit
 
-You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to [npm…][3]):
+You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to [npm][3]):
 
 4.  Within folder *remark-my-plugin* run
 
@@ -122,17 +122,17 @@ You're now set with your plug-in. The next part will make your package usuable o
 
     This creates a symlink in the system-global `node_modules` folder.
 
-5.  `cd` into your [glossarify-md…][1] project and create a symlink onto the global symlink:
+5.  `cd` into your [glossarify-md][1] project and create a symlink onto the global symlink:
 
         npm link remark-my-plugin
 
-You now virtually "installed" your plug-in into your [glossarify-md…][1] project similar as if you had run `npm install remark-my-plugin` to fetch it from the [npm…][3] registry.
+You now virtually "installed" your plug-in into your [glossarify-md][1] project similar as if you had run `npm install remark-my-plugin` to fetch it from the [npm][3] registry.
 
 > **Important:** Be aware that step 5 needs to be repeated whenever you ran `npm install` in your glossarify-md project).
 
-What's left is configuring [glossarify-md…][1] to use it (see also previous section):
+What's left is configuring [glossarify-md][1] to use it (see also previous section):
 
-6.  Add to your *[glossarify-md…][1].conf.json*
+6.  Add to your *[glossarify-md][1].conf.json*
 
         unified: {
            "plugins": ["remark-my-plugin"]

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -12,7 +12,7 @@
 
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
-The following example demonstrates how to install a [remark plug-in][remark-plugin]. The plug-in will extend [glossarify-md⎆][1]'s markdown parser [remark⎆][2]  with support for *Frontmatter* syntax.
+The following example demonstrates how to install a [remark plug-in][remark-plugin]. The plug-in will extend glossarify-md's markdown parser remark  with support for *Frontmatter* syntax.
 
 > **☛ Note:** glossarify-md does not guarantee compatibility with plug-ins and likely won't help with issues arising due to installing and using additional third-party plug-ins.
 
@@ -43,9 +43,9 @@ We'll assume the following file structure:
 
     npm install remark-frontmatter
 
-**3:** Make [remark⎆][2] load the plug-in by adding to your `remark.conf.json`:
+**3:** Make remark load the plug-in by adding to your `remark.conf.json`:
 
-*[remark⎆][2].conf.js*
+*remark.conf.js*
 
 ```json
 {
@@ -58,10 +58,10 @@ We'll assume the following file structure:
 }
 ```
 
-1.  `remark-frontmatter` must be the name of the [npm⎆][3] package you installed before
+1.  `remark-frontmatter` must be the name of the npm package you installed before
 2.  any properties of the `remark-frontmatter` object are options specific to the plug-in.
 
-`remark.conf.json` follows the [unified configuration][unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *[glossarify-md⎆][1]*'s config schema.
+`remark.conf.json` follows the [unified configuration][unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *glossarify-md*'s config schema.
 
 > **ⓘ remark, unified, uhh... ?**
 >
@@ -69,9 +69,9 @@ We'll assume the following file structure:
 
 ## [Writing a Plug-In](#writing-a-plug-in)
 
-Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this [remark discussion and little ASCII-art][remark-discussion] helpful. Have a look at [micromark⎆][4] and [remark⎆][2] for a reference, though.
+Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this [remark discussion and little ASCII-art][remark-discussion] helpful. Have a look at micromark and remark for a reference, though.
 
-A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree (\[mdAST]\[mdast]). [glossarify-md⎆][1] itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
+A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree (\[mdAST]\[mdast]). glossarify-md itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
 
 A tree plug-in is a function which returns a callback that when called get's passed an \[mdAST]:
 
@@ -93,11 +93,11 @@ export default function myPlugin(options = {}) {
 }
 ```
 
-The example uses a [visit][mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's [URL🟉][5] and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of [CommonMark⎆][6] node types see \[mdAST].
+The example uses a [visit][mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's [URL🟉][1] and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of CommonMark node types see \[mdAST].
 
-Here's how you can set up a plug-in project next to a [glossarify-md⎆][1] project:
+Here's how you can set up a plug-in project next to a glossarify-md project:
 
-1.  Make a new directory *remark-my-plugin* and initialize it as an [npm⎆][3] package.
+1.  Make a new directory *remark-my-plugin* and initialize it as an npm package.
 
         mkdir ./remark-my-plugin
         cd ./remark-my-plugin
@@ -110,11 +110,11 @@ Here's how you can set up a plug-in project next to a [glossarify-md⎆][1] proj
 
 3.  Copy the JavaScript code sample above into `index.js`
 
-4.  Install the [npm⎆][3] dependency required by the code sample
+4.  Install the npm dependency required by the code sample
 
         npm install unist-util-visit
 
-You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to [npm⎆][3]):
+You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to npm):
 
 4.  Within folder *remark-my-plugin* run
 
@@ -122,17 +122,17 @@ You're now set with your plug-in. The next part will make your package usuable o
 
     This creates a symlink in the system-global `node_modules` folder.
 
-5.  `cd` into your [glossarify-md⎆][1] project and create a symlink onto the global symlink:
+5.  `cd` into your glossarify-md project and create a symlink onto the global symlink:
 
         npm link remark-my-plugin
 
-You now virtually "installed" your plug-in into your [glossarify-md⎆][1] project similar as if you had run `npm install remark-my-plugin` to fetch it from the [npm⎆][3] registry.
+You now virtually "installed" your plug-in into your glossarify-md project similar as if you had run `npm install remark-my-plugin` to fetch it from the npm registry.
 
 > **Important:** Be aware that step 5 needs to be repeated whenever you ran `npm install` in your glossarify-md project).
 
-What's left is configuring [glossarify-md⎆][1] to use it (see also previous section):
+What's left is configuring glossarify-md to use it (see also previous section):
 
-6.  Add to your *[glossarify-md⎆][1].conf.json*
+6.  Add to your *glossarify-md.conf.json*
 
         unified: {
            "plugins": ["remark-my-plugin"]
@@ -140,18 +140,8 @@ What's left is configuring [glossarify-md⎆][1] to use it (see also previous se
 
 7.  Run glossarify and see whether link output changed.
 
-If you succeeded you may want to familiarize yourself with [publishing your node package][7].
+If you succeeded you may want to familiarize yourself with [publishing your node package][2].
 
-[1]: https://github.com/about-code/glossarify-md "This project."
+[1]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[2]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
-
-[3]: references.md#npm "Node Package Manager."
-
-[4]: https://github.com/micromark/ "A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing)."
-
-[5]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
-
-[6]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
-
-[7]: https://docs.npmjs.com/packages-and-modules
+[2]: https://docs.npmjs.com/packages-and-modules

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -12,7 +12,7 @@
 
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
-The following example demonstrates how to install a [remark plug-in][remark-plugin]. The plug-in will extend glossarify-md's markdown parser remark  with support for *Frontmatter* syntax.
+The following example demonstrates how to install a [remark plug-in][remark-plugin]. The plug-in will extend [glossarify-md…][1]'s markdown parser [remark…][2]  with support for *Frontmatter* syntax.
 
 > **☛ Note:** glossarify-md does not guarantee compatibility with plug-ins and likely won't help with issues arising due to installing and using additional third-party plug-ins.
 
@@ -43,9 +43,9 @@ We'll assume the following file structure:
 
     npm install remark-frontmatter
 
-**3:** Make remark load the plug-in by adding to your `remark.conf.json`:
+**3:** Make [remark…][2] load the plug-in by adding to your `remark.conf.json`:
 
-*remark.conf.js*
+*[remark…][2].conf.js*
 
 ```json
 {
@@ -58,10 +58,10 @@ We'll assume the following file structure:
 }
 ```
 
-1.  `remark-frontmatter` must be the name of the npm package you installed before
+1.  `remark-frontmatter` must be the name of the [npm…][3] package you installed before
 2.  any properties of the `remark-frontmatter` object are options specific to the plug-in.
 
-`remark.conf.json` follows the [unified configuration][unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *glossarify-md*'s config schema.
+`remark.conf.json` follows the [unified configuration][unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *[glossarify-md…][1]*'s config schema.
 
 > **ⓘ remark, unified, uhh... ?**
 >
@@ -69,9 +69,9 @@ We'll assume the following file structure:
 
 ## [Writing a Plug-In](#writing-a-plug-in)
 
-Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this [remark discussion and little ASCII-art][remark-discussion] helpful. Have a look at micromark and remark for a reference, though.
+Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this [remark discussion and little ASCII-art][remark-discussion] helpful. Have a look at [micromark…][4] and [remark…][2] for a reference, though.
 
-A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree (\[mdAST]\[mdast]). glossarify-md itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
+A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree (\[mdAST]\[mdast]). [glossarify-md…][1] itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
 
 A tree plug-in is a function which returns a callback that when called get's passed an \[mdAST]:
 
@@ -93,11 +93,11 @@ export default function myPlugin(options = {}) {
 }
 ```
 
-The example uses a [visit][mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's [URL🟉][1] and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of CommonMark node types see \[mdAST].
+The example uses a [visit][mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's [URL🟉][5] and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of [CommonMark…][6] node types see \[mdAST].
 
-Here's how you can set up a plug-in project next to a glossarify-md project:
+Here's how you can set up a plug-in project next to a [glossarify-md…][1] project:
 
-1.  Make a new directory *remark-my-plugin* and initialize it as an npm package.
+1.  Make a new directory *remark-my-plugin* and initialize it as an [npm…][3] package.
 
         mkdir ./remark-my-plugin
         cd ./remark-my-plugin
@@ -110,11 +110,11 @@ Here's how you can set up a plug-in project next to a glossarify-md project:
 
 3.  Copy the JavaScript code sample above into `index.js`
 
-4.  Install the npm dependency required by the code sample
+4.  Install the [npm…][3] dependency required by the code sample
 
         npm install unist-util-visit
 
-You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to npm):
+You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to [npm…][3]):
 
 4.  Within folder *remark-my-plugin* run
 
@@ -122,17 +122,17 @@ You're now set with your plug-in. The next part will make your package usuable o
 
     This creates a symlink in the system-global `node_modules` folder.
 
-5.  `cd` into your glossarify-md project and create a symlink onto the global symlink:
+5.  `cd` into your [glossarify-md…][1] project and create a symlink onto the global symlink:
 
         npm link remark-my-plugin
 
-You now virtually "installed" your plug-in into your glossarify-md project similar as if you had run `npm install remark-my-plugin` to fetch it from the npm registry.
+You now virtually "installed" your plug-in into your [glossarify-md…][1] project similar as if you had run `npm install remark-my-plugin` to fetch it from the [npm…][3] registry.
 
 > **Important:** Be aware that step 5 needs to be repeated whenever you ran `npm install` in your glossarify-md project).
 
-What's left is configuring glossarify-md to use it (see also previous section):
+What's left is configuring [glossarify-md…][1] to use it (see also previous section):
 
-6.  Add to your *glossarify-md.conf.json*
+6.  Add to your *[glossarify-md…][1].conf.json*
 
         unified: {
            "plugins": ["remark-my-plugin"]
@@ -140,8 +140,18 @@ What's left is configuring glossarify-md to use it (see also previous section):
 
 7.  Run glossarify and see whether link output changed.
 
-If you succeeded you may want to familiarize yourself with [publishing your node package][2].
+If you succeeded you may want to familiarize yourself with [publishing your node package][7].
 
-[1]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+[1]: https://github.com/about-code/glossarify-md "This project."
 
-[2]: https://docs.npmjs.com/packages-and-modules
+[2]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+
+[3]: _references.md#npm "Node Package Manager."
+
+[4]: https://github.com/micromark/ "A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing)."
+
+[5]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+
+[6]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+
+[7]: https://docs.npmjs.com/packages-and-modules

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -2,17 +2,17 @@
 
 [doc-conceptual-layers]: ./conceptual-layers.md
 
-[CommonMark][1]: [https://www.commonmark.org][2]
-[glossarify-md][3]: [https://github.com/about-code/glossarify-md][4]
-\[mdast-util-visit]: [https://npmjs.com/package/mdast-util-visit][5]
-[micromark][6]: [https://github.com/micromark/][7]
-\[remark-discussion]: [https://github.com/remarkjs/remark/discussions/869#discussioncomment-1602674][8]
-\[remark-frontmatter]: [https://npmjs.com/package/remark-frontmatter][9]
-\[remark-plugin]: [https://github.com/remarkjs/awesome-remark][10]
-[unified][11]: [https://unifiedjs.com][12]
-\[unified-config]: [https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md][13]
+[mdast-util-visit]: https://npmjs.com/package/mdast-util-visit
 
-The following example demonstrates how to install a \[[remark][14] plug-in]\[remark-plugin]. The plug-in will extend [glossarify-md][3]'s markdown parser remark  with support for *Frontmatter* syntax.
+[remark-discussion]: https://github.com/remarkjs/remark/discussions/869#discussioncomment-1602674
+
+[remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
+
+[remark-plugin]: https://github.com/remarkjs/awesome-remark
+
+[unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
+
+The following example demonstrates how to install a [remark plug-in][remark-plugin]. The plug-in will extend [glossarify-md⎆][1]'s markdown parser [remark⎆][2]  with support for *Frontmatter* syntax.
 
 > **☛ Note:** glossarify-md does not guarantee compatibility with plug-ins and likely won't help with issues arising due to installing and using additional third-party plug-ins.
 
@@ -39,13 +39,13 @@ We'll assume the following file structure:
 
 `rcPath` is interpreted relative to `outDir`, so you need to "step out" of it.
 
-**2:** Then install a \[[remark][14] plug-in]\[remark-plugin]
+**2:** Then install a [remark plug-in][remark-plugin]
 
     npm install remark-frontmatter
 
-**3:** Make [remark][14] load the plug-in by adding to your `remark.conf.json`:
+**3:** Make [remark⎆][2] load the plug-in by adding to your `remark.conf.json`:
 
-*[remark][14].conf.js*
+*[remark⎆][2].conf.js*
 
 ```json
 {
@@ -58,10 +58,10 @@ We'll assume the following file structure:
 }
 ```
 
-1.  `remark-frontmatter` must be the name of the [npm][15] package you installed before
+1.  `remark-frontmatter` must be the name of the [npm⎆][3] package you installed before
 2.  any properties of the `remark-frontmatter` object are options specific to the plug-in.
 
-`remark.conf.json` follows the \[[unified][11] configuration]\[unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *[glossarify-md][3]*'s config schema.
+`remark.conf.json` follows the [unified configuration][unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *[glossarify-md⎆][1]*'s config schema.
 
 > **ⓘ remark, unified, uhh... ?**
 >
@@ -69,9 +69,9 @@ We'll assume the following file structure:
 
 ## [Writing a Plug-In](#writing-a-plug-in)
 
-Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this \[[remark][14] discussion and little ASCII-art]\[remark-discussion] helpful. Have a look at [micromark][6] and remark for a reference, though.
+Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this [remark discussion and little ASCII-art][remark-discussion] helpful. Have a look at [micromark⎆][4] and [remark⎆][2] for a reference, though.
 
-A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree (\[mdAST]\[mdast]). [glossarify-md][3] itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
+A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree (\[mdAST]\[mdast]). [glossarify-md⎆][1] itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
 
 A tree plug-in is a function which returns a callback that when called get's passed an \[mdAST]:
 
@@ -93,11 +93,11 @@ export default function myPlugin(options = {}) {
 }
 ```
 
-The example uses a \[visit]\[mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's [URL🟉][16] and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of [CommonMark][1] node types see \[mdAST].
+The example uses a [visit][mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's [URL🟉][5] and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of [CommonMark⎆][6] node types see \[mdAST].
 
-Here's how you can set up a plug-in project next to a [glossarify-md][3] project:
+Here's how you can set up a plug-in project next to a [glossarify-md⎆][1] project:
 
-1.  Make a new directory *remark-my-plugin* and initialize it as an [npm][15] package.
+1.  Make a new directory *remark-my-plugin* and initialize it as an [npm⎆][3] package.
 
         mkdir ./remark-my-plugin
         cd ./remark-my-plugin
@@ -110,11 +110,11 @@ Here's how you can set up a plug-in project next to a [glossarify-md][3] project
 
 3.  Copy the JavaScript code sample above into `index.js`
 
-4.  Install the [npm][15] dependency required by the code sample
+4.  Install the [npm⎆][3] dependency required by the code sample
 
         npm install unist-util-visit
 
-You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to [npm][15]):
+You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to [npm⎆][3]):
 
 4.  Within folder *remark-my-plugin* run
 
@@ -122,17 +122,17 @@ You're now set with your plug-in. The next part will make your package usuable o
 
     This creates a symlink in the system-global `node_modules` folder.
 
-5.  `cd` into your [glossarify-md][3] project and create a symlink onto the global symlink:
+5.  `cd` into your [glossarify-md⎆][1] project and create a symlink onto the global symlink:
 
         npm link remark-my-plugin
 
-You now virtually "installed" your plug-in into your [glossarify-md][3] project similar as if you had run `npm install remark-my-plugin` to fetch it from the [npm][15] registry.
+You now virtually "installed" your plug-in into your [glossarify-md⎆][1] project similar as if you had run `npm install remark-my-plugin` to fetch it from the [npm⎆][3] registry.
 
 > **Important:** Be aware that step 5 needs to be repeated whenever you ran `npm install` in your glossarify-md project).
 
-What's left is configuring [glossarify-md][3] to use it (see also previous section):
+What's left is configuring [glossarify-md⎆][1] to use it (see also previous section):
 
-6.  Add to your *[glossarify-md][3].conf.json*
+6.  Add to your *[glossarify-md⎆][1].conf.json*
 
         unified: {
            "plugins": ["remark-my-plugin"]
@@ -140,38 +140,18 @@ What's left is configuring [glossarify-md][3] to use it (see also previous secti
 
 7.  Run glossarify and see whether link output changed.
 
-If you succeeded you may want to familiarize yourself with [publishing your node package][17].
+If you succeeded you may want to familiarize yourself with [publishing your node package][7].
 
-[1]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+[1]: https://github.com/about-code/glossarify-md "This project."
 
-[2]: https://www.commonmark.org
+[2]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
 
-[3]: https://github.com/about-code/glossarify-md "This project."
+[3]: references.md#npm "Node Package Manager."
 
-[4]: https://github.com/about-code/glossarify-md
+[4]: https://github.com/micromark/ "A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing)."
 
-[5]: https://npmjs.com/package/mdast-util-visit
+[5]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[6]: https://github.com/micromark/ "A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing)."
+[6]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
 
-[7]: https://github.com/micromark/
-
-[8]: https://github.com/remarkjs/remark/discussions/869#discussioncomment-1602674
-
-[9]: https://npmjs.com/package/remark-frontmatter
-
-[10]: https://github.com/remarkjs/awesome-remark
-
-[11]: https://unifiedjs.com "unified is an umbrella project around text file processing in general."
-
-[12]: https://unifiedjs.com
-
-[13]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
-
-[14]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
-
-[15]: references.md#npm "Node Package Manager."
-
-[16]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
-
-[17]: https://docs.npmjs.com/packages-and-modules
+[7]: https://docs.npmjs.com/packages-and-modules

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -2,33 +2,19 @@
 
 [doc-conceptual-layers]: ./conceptual-layers.md
 
-[CommonMark]: https://www.commonmark.org
+[CommonMark][1]: [https://www.commonmark.org][2]
+[glossarify-md][3]: [https://github.com/about-code/glossarify-md][4]
+\[mdast-util-visit]: [https://npmjs.com/package/mdast-util-visit][5]
+[micromark][6]: [https://github.com/micromark/][7]
+\[remark-discussion]: [https://github.com/remarkjs/remark/discussions/869#discussioncomment-1602674][8]
+\[remark-frontmatter]: [https://npmjs.com/package/remark-frontmatter][9]
+\[remark-plugin]: [https://github.com/remarkjs/awesome-remark][10]
+[unified][11]: [https://unifiedjs.com][12]
+\[unified-config]: [https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md][13]
 
-[glossarify-md]: https://github.com/about-code/glossarify-md
+The following example demonstrates how to install a \[[remark][14] plug-in]\[remark-plugin]. The plug-in will extend [glossarify-md][3]'s markdown parser remark  with support for *Frontmatter* syntax.
 
-[mdast]: https://github.com/syntax-tree/mdast
-
-[mdast-util-visit]: https://npmjs.com/package/mdast-util-visit
-
-[micromark]: https://github.com/micromark/
-
-[npm]: https://npmjs.com
-
-[remark]: https://github.com/remarkjs/remark
-
-[remark-discussion]: https://github.com/remarkjs/remark/discussions/869#discussioncomment-1602674
-
-[remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
-
-[remark-plugin]: https://github.com/remarkjs/awesome-remark
-
-[unified]: https://unifiedjs.com
-
-[unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
-
-The following example demonstrates how to install a [remark plug-in][remark-plugin]. The plug-in will extend [glossarify-md]'s markdown parser [remark]  with support for *Frontmatter* syntax.
-
-> **☛ Note:** [glossarify-md] does not guarantee compatibility with plug-ins and likely won't help with issues arising due to installing and using additional third-party plug-ins.
+> **☛ Note:** glossarify-md does not guarantee compatibility with plug-ins and likely won't help with issues arising due to installing and using additional third-party plug-ins.
 
 We'll assume the following file structure:
 
@@ -53,13 +39,13 @@ We'll assume the following file structure:
 
 `rcPath` is interpreted relative to `outDir`, so you need to "step out" of it.
 
-**2:** Then install a [remark plug-in][remark-plugin]
+**2:** Then install a \[[remark][14] plug-in]\[remark-plugin]
 
     npm install remark-frontmatter
 
-**3:** Make [remark🟉][1] load the plug-in by adding to your `remark.conf.json`:
+**3:** Make [remark][14] load the plug-in by adding to your `remark.conf.json`:
 
-*[remark🟉][1].conf.js*
+*[remark][14].conf.js*
 
 ```json
 {
@@ -72,22 +58,22 @@ We'll assume the following file structure:
 }
 ```
 
-1.  `remark-frontmatter` must be the name of the npm package you installed before
+1.  `remark-frontmatter` must be the name of the [npm][15] package you installed before
 2.  any properties of the `remark-frontmatter` object are options specific to the plug-in.
 
-`remark.conf.json` follows the [unified configuration][unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *[glossarify-md]*'s config schema.
+`remark.conf.json` follows the \[[unified][11] configuration]\[unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *[glossarify-md][3]*'s config schema.
 
-> **ⓘ [remark], [unified], uhh... ?**
+> **ⓘ remark, unified, uhh... ?**
 >
-> Read more on how these projects relate to [glossarify-md] in [Conceptual Layers][doc-conceptual-layers].
+> Read more on how these projects relate to glossarify-md in [Conceptual Layers][doc-conceptual-layers].
 
 ## [Writing a Plug-In](#writing-a-plug-in)
 
-Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this [remark discussion and little ASCII-art][remark-discussion] helpful. Have a look at [micromark] and [remark] for a reference, though.
+Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this \[[remark][14] discussion and little ASCII-art]\[remark-discussion] helpful. Have a look at [micromark][6] and remark for a reference, though.
 
-A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree ([mdAST][mdast]). [glossarify-md] itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
+A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree (\[mdAST]\[mdast]). [glossarify-md][3] itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
 
-A tree plug-in is a function which returns a callback that when called get's passed an [mdAST]:
+A tree plug-in is a function which returns a callback that when called get's passed an \[mdAST]:
 
 ```js
 import { visit } from "unist-util-visit";
@@ -107,11 +93,11 @@ export default function myPlugin(options = {}) {
 }
 ```
 
-The example uses a [visit][mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's [URL🟉][2] and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of [CommonMark] node types see [mdAST].
+The example uses a \[visit]\[mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's [URL🟉][16] and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of [CommonMark][1] node types see \[mdAST].
 
-Here's how you can set up a plug-in project next to a glossarify-md project:
+Here's how you can set up a plug-in project next to a [glossarify-md][3] project:
 
-1.  Make a new directory *remark-my-plugin* and initialize it as an npm package.
+1.  Make a new directory *remark-my-plugin* and initialize it as an [npm][15] package.
 
         mkdir ./remark-my-plugin
         cd ./remark-my-plugin
@@ -124,11 +110,11 @@ Here's how you can set up a plug-in project next to a glossarify-md project:
 
 3.  Copy the JavaScript code sample above into `index.js`
 
-4.  Install the npm dependency required by the code sample
+4.  Install the [npm][15] dependency required by the code sample
 
         npm install unist-util-visit
 
-You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to [npm]):
+You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to [npm][15]):
 
 4.  Within folder *remark-my-plugin* run
 
@@ -136,17 +122,17 @@ You're now set with your plug-in. The next part will make your package usuable o
 
     This creates a symlink in the system-global `node_modules` folder.
 
-5.  `cd` into your [glossarify-md] project and create a symlink onto the global symlink:
+5.  `cd` into your [glossarify-md][3] project and create a symlink onto the global symlink:
 
         npm link remark-my-plugin
 
-You now virtually "installed" your plug-in into your [glossarify-md] project similar as if you had run `npm install remark-my-plugin` to fetch it from the [npm] registry.
+You now virtually "installed" your plug-in into your [glossarify-md][3] project similar as if you had run `npm install remark-my-plugin` to fetch it from the [npm][15] registry.
 
-> **Important:** Be aware that step 5 needs to be repeated whenever you ran `npm install` in your [glossarify-md] project).
+> **Important:** Be aware that step 5 needs to be repeated whenever you ran `npm install` in your glossarify-md project).
 
-What's left is configuring [glossarify-md] to use it (see also previous section):
+What's left is configuring [glossarify-md][3] to use it (see also previous section):
 
-6.  Add to your *glossarify-md.conf.json*
+6.  Add to your *[glossarify-md][3].conf.json*
 
         unified: {
            "plugins": ["remark-my-plugin"]
@@ -154,10 +140,38 @@ What's left is configuring [glossarify-md] to use it (see also previous section)
 
 7.  Run glossarify and see whether link output changed.
 
-If you succeeded you may want to familiarize yourself with [publishing your node package][3].
+If you succeeded you may want to familiarize yourself with [publishing your node package][17].
 
-[1]: ./glossary.md#remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+[1]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
 
-[2]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+[2]: https://www.commonmark.org
 
-[3]: https://docs.npmjs.com/packages-and-modules
+[3]: https://github.com/about-code/glossarify-md "This project."
+
+[4]: https://github.com/about-code/glossarify-md
+
+[5]: https://npmjs.com/package/mdast-util-visit
+
+[6]: https://github.com/micromark/ "A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing)."
+
+[7]: https://github.com/micromark/
+
+[8]: https://github.com/remarkjs/remark/discussions/869#discussioncomment-1602674
+
+[9]: https://npmjs.com/package/remark-frontmatter
+
+[10]: https://github.com/remarkjs/awesome-remark
+
+[11]: https://unifiedjs.com "unified is an umbrella project around text file processing in general."
+
+[12]: https://unifiedjs.com
+
+[13]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
+
+[14]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+
+[15]: references.md#npm "Node Package Manager."
+
+[16]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+
+[17]: https://docs.npmjs.com/packages-and-modules

--- a/doc/references.md
+++ b/doc/references.md
@@ -4,7 +4,7 @@
 
 <!--{"uri": "https://atom.io" }-->
 
-[Atom][1] Code Editor.
+[Atom⎆][1] Code Editor.
 
 ## [CommonMark](#commonmark)
 
@@ -19,7 +19,7 @@ Effort on providing a minimal set of standardized Markdown syntax.
     "aliases": "DC, DublinCore, dc:"
 }-->
 
-The [Dublin Core][2] Metadata Initiative.
+The [Dublin Core⎆][2] Metadata Initiative.
 
 ## [GFM](#gfm)
 
@@ -28,19 +28,19 @@ The [Dublin Core][2] Metadata Initiative.
     "aliases": "GFM, GitHub Flavoured Markdown, GitHub Flavored Markdown"
 }-->
 
-[GitHub Flavoured Markdown][3]
+[GitHub Flavoured Markdown⎆][3]
 
 ## [github-slugger](#github-slugger)
 
 <!--{"uri": "https://npmjs.com/package/github-slugger" }-->
 
-A library providing support for [slugs🟉][4]. See [github-slugger][5].
+A library providing support for [slugs🟉][4]. See [github-slugger⎆][5].
 
 ## [glob](#glob)
 
 <!--{"uri": "https://github.com/isaacs/node-glob#glob-primer" }-->
 
-A file pattern matcher. See [glob][6].
+A file pattern matcher. See [glob⎆][6].
 
 ## [glossarify-md](#glossarify-md)
 
@@ -61,7 +61,7 @@ A static website renderer compiling an HTML website from Markdown files.
     "aliases": "JSON-LD Spec"
 }-->
 
-[JSON-LD][7] is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public [vocabularies🟉][8]. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. [SKOS][9] is one such vocabulary supported by [glossarify-md][10]
+[JSON-LD⎆][7] is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public [vocabularies🟉][8]. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. [SKOS⎆][9] is one such vocabulary supported by [glossarify-md⎆][10]
 
 ## [jsonld Library](#jsonld-library)
 
@@ -70,7 +70,7 @@ A static website renderer compiling an HTML website from Markdown files.
     "aliases": "jsonld"
 }-->
 
-A JavaScript implementation of [JSON-LD][7].
+A JavaScript implementation of [JSON-LD⎆][7].
 
 ## [Linked Data](#linked-data)
 
@@ -79,7 +79,7 @@ A JavaScript implementation of [JSON-LD][7].
     "aliases": "LD"
 }-->
 
-See [Linked Data][11].
+See [Linked Data⎆][11].
 
 ## [mdAst](#mdast)
 
@@ -94,13 +94,13 @@ Specification and Implementation of a Markdown Abstract Syntax Tree.
 
 <!--{"uri": "https://github.com/micromark/" }-->
 
-A low-level extensible implementation of the [CommonMark][12] syntax specification (parsing and tokenizing).
+A low-level extensible implementation of the [CommonMark⎆][12] syntax specification (parsing and tokenizing).
 
 ## [npm](#npm)
 
 <!-- {"uri": "https://npmjs.com"}-->
 
-Node Package Manager. See [npm][13].
+Node Package Manager. See [npm⎆][13].
 
 ## [OWL](#owl)
 
@@ -112,37 +112,37 @@ Web Ontology Language.
 
 <!--{"uri": "https://pandoc.org" }-->
 
-See [pandoc][14].
+See [pandoc⎆][14].
 
 ## [PlantUML](#plantuml)
 
 <!--{"uri": "https://plantuml.com" }-->
 
-Generates diagrams from text files written in the [PlantUML][15] syntax.
+Generates diagrams from text files written in the [PlantUML⎆][15] syntax.
 
 ## [remark](#remark)
 
 <!--{"uri": "https://github.com/remarkjs/remark" }-->
 
-*[remark][16]* is a parser and compiler project under the [unified][17] umbrella for *Markdown* text files in particular.
+*[remark⎆][16]* is a parser and compiler project under the [unified⎆][17] umbrella for *Markdown* text files in particular.
 
 ## [SKOS](#skos)
 
 <!--{ "uri": "http://w3.org/skos/" }-->
 
-With the Simple [Knowledge Organization System🟉][18] ([SKOS][9]) the World Wide Web Consortium (W3C) has standardized a (meta-)[vocabulary🟉][8] which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
+With the Simple [Knowledge Organization System🟉][18] ([SKOS⎆][9]) the World Wide Web Consortium (W3C) has standardized a (meta-)[vocabulary🟉][8] which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
 
 ## [unified](#unified)
 
 <!--{ "uri": "https://unifiedjs.com" }-->
 
-*[unified][17]* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md][19]
+*[unified⎆][17]* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md][19]
 
 ## [URN](#urn)
 
 <!--{ "uri": "https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml" }-->
 
-Uniform Resource Names. See [URN][20].
+Uniform Resource Names. See [URN⎆][20].
 
 ## [VSCode](#vscode)
 
@@ -150,7 +150,7 @@ Uniform Resource Names. See [URN][20].
 
 [Code-OSS]: https://github.com/microsoft/vscode
 
-Visual Studio Code. See [VSCode][21] or [Code-OSS].
+Visual Studio Code. See [VSCode⎆][21] or [Code-OSS].
 
 ## [vuepress](#vuepress)
 

--- a/doc/references.md
+++ b/doc/references.md
@@ -1,0 +1,207 @@
+# [References](#references)
+
+## [Atom](#atom)
+
+<!--{"uri": "https://atom.io" }-->
+
+[Atom][1] Code Editor.
+
+## [CommonMark](#commonmark)
+
+<!--{ "uri": "https://commonmark.org" }-->
+
+Effort on providing a minimal set of standardized Markdown syntax.
+
+## [Dublin Core](#dublin-core)
+
+<!--{
+    "uri": "http://purl.org/dc/terms/",
+    "aliases": "DC, DublinCore, dc:"
+}-->
+
+The [Dublin Core][2] Metadata Initiative.
+
+## [GFM](#gfm)
+
+<!--{
+    "uri": "https://github.github.com/gfm/",
+    "aliases": "GFM, GitHub Flavoured Markdown, GitHub Flavored Markdown"
+}-->
+
+[GitHub Flavoured Markdown][3]
+
+## [github-slugger](#github-slugger)
+
+<!--{"uri": "https://npmjs.com/package/github-slugger" }-->
+
+A library providing support for [slugs🟉][4]. See [github-slugger][5].
+
+## [glob](#glob)
+
+<!--{"uri": "https://github.com/isaacs/node-glob#glob-primer" }-->
+
+A file pattern matcher. See [glob][6].
+
+## [glossarify-md](#glossarify-md)
+
+<!--{"uri": "https://github.com/about-code/glossarify-md" }-->
+
+This project.
+
+## [Jekyll](#jekyll)
+
+<!--{"uri": "https://jekyllrb.com" }-->
+
+A static website renderer compiling an HTML website from Markdown files.
+
+## [JSON-LD](#json-ld)
+
+<!--{
+    "uri": "https://json-ld.org",
+    "aliases": "JSON-LD Spec"
+}-->
+
+[JSON-LD][7] is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public [vocabularies🟉][8]. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. [SKOS][9] is one such vocabulary supported by [glossarify-md][10]
+
+## [jsonld Library](#jsonld-library)
+
+<!--{
+    "uri": "https://npmjs.com/package/jsonld",
+    "aliases": "jsonld"
+}-->
+
+A JavaScript implementation of [JSON-LD][7].
+
+## [Linked Data](#linked-data)
+
+<!--{
+    "uri": "https://www.w3.org/standards/semanticweb/ontology",
+    "aliases": "LD"
+}-->
+
+See [Linked Data][11].
+
+## [mdAst](#mdast)
+
+<!--{
+    "uri": "https://github.com/syntax-tree/mdast",
+    "aliases": "mdAST, mdast"
+}-->
+
+Specification and Implementation of a Markdown Abstract Syntax Tree.
+
+## [micromark](#micromark)
+
+<!--{"uri": "https://github.com/micromark/" }-->
+
+A low-level extensible implementation of the [CommonMark][12] syntax specification (parsing and tokenizing).
+
+## [npm](#npm)
+
+<!-- {"uri": "https://npmjs.com"}-->
+
+Node Package Manager. See [npm][13].
+
+## [OWL](#owl)
+
+<!--{"uri": "https://www.w3.org/TR/2012/REC-owl2-overview-20121211/" }-->
+
+Web Ontology Language.
+
+## [pandoc](#pandoc)
+
+<!--{"uri": "https://pandoc.org" }-->
+
+See [pandoc][14].
+
+## [PlantUML](#plantuml)
+
+<!--{"uri": "https://plantuml.com" }-->
+
+Generates diagrams from text files written in the [PlantUML][15] syntax.
+
+## [remark](#remark)
+
+<!--{"uri": "https://github.com/remarkjs/remark" }-->
+
+*[remark][16]* is a parser and compiler project under the [unified][17] umbrella for *Markdown* text files in particular.
+
+## [SKOS](#skos)
+
+<!--{ "uri": "http://w3.org/skos/" }-->
+
+With the Simple [Knowledge Organization System🟉][18] ([SKOS][9]) the World Wide Web Consortium (W3C) has standardized a (meta-)[vocabulary🟉][8] which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
+
+## [unified](#unified)
+
+<!--{ "uri": "https://unifiedjs.com" }-->
+
+*[unified][17]* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md][19]
+
+## [URN](#urn)
+
+<!--{ "uri": "https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml" }-->
+
+Uniform Resource Names. See [URN][20].
+
+## [VSCode](#vscode)
+
+<!--{ "uri": "https://code.visualstudio.com" }-->
+
+[Code-OSS]: https://github.com/microsoft/vscode
+
+Visual Studio Code. See [VSCode][21] or [Code-OSS].
+
+## [vuepress](#vuepress)
+
+<!--{"uri": "https://vuepress.vuejs.org" }-->
+
+A static website generator translating markdown files into a website powered by \[vuejs].
+
+## [vuejs](#vuejs)
+
+<!--{"uri": "https://vuejs.org" }-->
+
+A Single Page Application framework written in JavaScript.
+
+[1]: https://atom.io "Atom Code Editor."
+
+[2]: http://purl.org/dc/terms/ "The Dublin Core Metadata Initiative."
+
+[3]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"
+
+[4]: ./glossary.md#slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
+
+[5]: https://npmjs.com/package/github-slugger "A library providing support for slugs."
+
+[6]: https://github.com/isaacs/node-glob#glob-primer "A file pattern matcher."
+
+[7]: https://json-ld.org "JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies."
+
+[8]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
+
+[9]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
+
+[10]: https://github.com/about-code/glossarify-md "This project."
+
+[11]: https://www.w3.org/standards/semanticweb/ontology "See Linked Data."
+
+[12]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+
+[13]: references.md#npm "Node Package Manager."
+
+[14]: https://pandoc.org "See pandoc."
+
+[15]: https://plantuml.com "Generates diagrams from text files written in the PlantUML syntax."
+
+[16]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+
+[17]: https://unifiedjs.com "unified is an umbrella project around text file processing in general."
+
+[18]: ./glossary.md#kos---knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
+
+[19]: ./conceptual-layers.md
+
+[20]: https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml "Uniform Resource Names."
+
+[21]: https://code.visualstudio.com "Visual Studio Code."

--- a/doc/references.md
+++ b/doc/references.md
@@ -3,7 +3,7 @@
 In order to cite a source on the web whenever using a particular [term🟉][1], use a
 glossary configuration with `linkUris: true`:
 
-*glossarify-md.conf.json*
+*[glossarify-md…][2].conf.json*
 
 ```json
 {
@@ -16,7 +16,7 @@ glossary configuration with `linkUris: true`:
 }
 ```
 
-Within file `./references.md` use the `uri` [term🟉][1] attribute to provide the source's [URL🟉][2]. Optionally you can add an `aliases` term attribute to make further terms refer to a particular source and provide a tooltip for the link.
+Within file `./references.md` use the `uri` [term🟉][1] attribute to provide the source's [URL🟉][3]. Optionally you can add an `aliases` term attribute to make further terms refer to a particular source and provide a tooltip for the link.
 
 *references.md*
 
@@ -32,12 +32,14 @@ Within file `./references.md` use the `uri` [term🟉][1] attribute to provide t
 The Dublin Core Metadata Initiative.
 ```
 
-See an example by inspecting the markdown source of [\_references.md][3] or this repository's [glossarify-md.conf.json][4].
+See an example by inspecting the markdown source of [\_references.md][4] or this repository's [glossarify-md.conf.json][5].
 
 [1]: ./glossary.md#term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 
-[2]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+[2]: https://github.com/about-code/glossarify-md "This project."
 
-[3]: ./_references.md
+[3]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[4]: ../glossarify-md.conf.json
+[4]: ./_references.md
+
+[5]: ../glossarify-md.conf.json

--- a/doc/references.md
+++ b/doc/references.md
@@ -1,207 +1,43 @@
-# [References](#references)
+# [Managing References](#managing-references)
 
-## [Atom](#atom)
+In order to cite a source on the web whenever using a particular [term🟉][1], use a
+glossary configuration with `linkUris: true`:
 
-<!--{"uri": "https://atom.io" }-->
+*glossarify-md.conf.json*
 
-[Atom⎆][1] Code Editor.
+```json
+{
+  "glossaries": [
+    {
+      "file": "./references.md",
+      "linkUris": true
+    }
+  ]
+}
+```
 
-## [CommonMark](#commonmark)
+Within file `./references.md` use the `uri` [term🟉][1] attribute to provide the source's [URL🟉][2]. Optionally you can add an `aliases` term attribute to make further terms refer to a particular source and provide a tooltip for the link.
 
+*references.md*
+
+```md
+## CommonMark
 <!--{ "uri": "https://commonmark.org" }-->
 
-Effort on providing a minimal set of standardized Markdown syntax.
-
-## [Dublin Core](#dublin-core)
-
+## Dublin Core
 <!--{
     "uri": "http://purl.org/dc/terms/",
     "aliases": "DC, DublinCore, dc:"
 }-->
+The Dublin Core Metadata Initiative.
+```
 
-The [Dublin Core⎆][2] Metadata Initiative.
+See an example by inspecting the markdown source of [\_references.md][3] or this repository's [glossarify-md.conf.json][4].
 
-## [GFM](#gfm)
+[1]: ./glossary.md#term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 
-<!--{
-    "uri": "https://github.github.com/gfm/",
-    "aliases": "GFM, GitHub Flavoured Markdown, GitHub Flavored Markdown"
-}-->
+[2]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[GitHub Flavoured Markdown⎆][3]
+[3]: ./_references.md
 
-## [github-slugger](#github-slugger)
-
-<!--{"uri": "https://npmjs.com/package/github-slugger" }-->
-
-A library providing support for [slugs🟉][4]. See [github-slugger⎆][5].
-
-## [glob](#glob)
-
-<!--{"uri": "https://github.com/isaacs/node-glob#glob-primer" }-->
-
-A file pattern matcher. See [glob⎆][6].
-
-## [glossarify-md](#glossarify-md)
-
-<!--{"uri": "https://github.com/about-code/glossarify-md" }-->
-
-This project.
-
-## [Jekyll](#jekyll)
-
-<!--{"uri": "https://jekyllrb.com" }-->
-
-A static website renderer compiling an HTML website from Markdown files.
-
-## [JSON-LD](#json-ld)
-
-<!--{
-    "uri": "https://json-ld.org",
-    "aliases": "JSON-LD Spec"
-}-->
-
-[JSON-LD⎆][7] is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public [vocabularies🟉][8]. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. [SKOS⎆][9] is one such vocabulary supported by [glossarify-md⎆][10]
-
-## [jsonld Library](#jsonld-library)
-
-<!--{
-    "uri": "https://npmjs.com/package/jsonld",
-    "aliases": "jsonld"
-}-->
-
-A JavaScript implementation of [JSON-LD⎆][7].
-
-## [Linked Data](#linked-data)
-
-<!--{
-    "uri": "https://www.w3.org/standards/semanticweb/ontology",
-    "aliases": "LD"
-}-->
-
-See [Linked Data⎆][11].
-
-## [mdAst](#mdast)
-
-<!--{
-    "uri": "https://github.com/syntax-tree/mdast",
-    "aliases": "mdAST, mdast"
-}-->
-
-Specification and Implementation of a Markdown Abstract Syntax Tree.
-
-## [micromark](#micromark)
-
-<!--{"uri": "https://github.com/micromark/" }-->
-
-A low-level extensible implementation of the [CommonMark⎆][12] syntax specification (parsing and tokenizing).
-
-## [npm](#npm)
-
-<!-- {"uri": "https://npmjs.com"}-->
-
-Node Package Manager. See [npm⎆][13].
-
-## [OWL](#owl)
-
-<!--{"uri": "https://www.w3.org/TR/2012/REC-owl2-overview-20121211/" }-->
-
-Web Ontology Language.
-
-## [pandoc](#pandoc)
-
-<!--{"uri": "https://pandoc.org" }-->
-
-See [pandoc⎆][14].
-
-## [PlantUML](#plantuml)
-
-<!--{"uri": "https://plantuml.com" }-->
-
-Generates diagrams from text files written in the [PlantUML⎆][15] syntax.
-
-## [remark](#remark)
-
-<!--{"uri": "https://github.com/remarkjs/remark" }-->
-
-*[remark⎆][16]* is a parser and compiler project under the [unified⎆][17] umbrella for *Markdown* text files in particular.
-
-## [SKOS](#skos)
-
-<!--{ "uri": "http://w3.org/skos/" }-->
-
-With the Simple [Knowledge Organization System🟉][18] ([SKOS⎆][9]) the World Wide Web Consortium (W3C) has standardized a (meta-)[vocabulary🟉][8] which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
-
-## [unified](#unified)
-
-<!--{ "uri": "https://unifiedjs.com" }-->
-
-*[unified⎆][17]* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md][19]
-
-## [URN](#urn)
-
-<!--{ "uri": "https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml" }-->
-
-Uniform Resource Names. See [URN⎆][20].
-
-## [VSCode](#vscode)
-
-<!--{ "uri": "https://code.visualstudio.com" }-->
-
-[Code-OSS]: https://github.com/microsoft/vscode
-
-Visual Studio Code. See [VSCode⎆][21] or [Code-OSS].
-
-## [vuepress](#vuepress)
-
-<!--{"uri": "https://vuepress.vuejs.org" }-->
-
-A static website generator translating markdown files into a website powered by \[vuejs].
-
-## [vuejs](#vuejs)
-
-<!--{"uri": "https://vuejs.org" }-->
-
-A Single Page Application framework written in JavaScript.
-
-[1]: https://atom.io "Atom Code Editor."
-
-[2]: http://purl.org/dc/terms/ "The Dublin Core Metadata Initiative."
-
-[3]: https://github.github.com/gfm/ "GitHub Flavoured Markdown"
-
-[4]: ./glossary.md#slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
-
-[5]: https://npmjs.com/package/github-slugger "A library providing support for slugs."
-
-[6]: https://github.com/isaacs/node-glob#glob-primer "A file pattern matcher."
-
-[7]: https://json-ld.org "JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies."
-
-[8]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
-
-[9]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
-
-[10]: https://github.com/about-code/glossarify-md "This project."
-
-[11]: https://www.w3.org/standards/semanticweb/ontology "See Linked Data."
-
-[12]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
-
-[13]: references.md#npm "Node Package Manager."
-
-[14]: https://pandoc.org "See pandoc."
-
-[15]: https://plantuml.com "Generates diagrams from text files written in the PlantUML syntax."
-
-[16]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
-
-[17]: https://unifiedjs.com "unified is an umbrella project around text file processing in general."
-
-[18]: ./glossary.md#kos---knowledge-organization-systems "Glossaries are considered a kind of Knowledge Organisation System (KOS) which organizes knowledge as a list of terms and term definitions."
-
-[19]: ./conceptual-layers.md
-
-[20]: https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml "Uniform Resource Names."
-
-[21]: https://code.visualstudio.com "Visual Studio Code."
+[4]: ../glossarify-md.conf.json

--- a/doc/references.md
+++ b/doc/references.md
@@ -1,7 +1,6 @@
 # [Managing References](#managing-references)
 
-In order to cite a source on the web whenever using a particular [term🟉][1], use a
-glossary configuration with `linkUris: true`:
+In order to cite a source on the web whenever using a particular [term🟉][1] use a glossary configuration with `linkUris: true`:
 
 *[glossarify-md][2].conf.json*
 
@@ -16,7 +15,7 @@ glossary configuration with `linkUris: true`:
 }
 ```
 
-Within file `./references.md` use the `uri` [term🟉][1] attribute to provide the source's [URL🟉][3]. Optionally you can add an `aliases` [term attribute🟉][4] to make further terms refer to a particular source and provide a tooltip for the link.
+Within file `./references.md` use the [term🟉][1] attribute `uri` to provide the source's [URL🟉][3]. Optionally you can add an `aliases` [term attribute🟉][4] to make further terms refer to a particular source and provide a tooltip for the link.
 
 *references.md*
 
@@ -40,7 +39,7 @@ See an example by inspecting the markdown source of [\_references.md][5] or this
 
 [3]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[4]: ./glossary.md#term-attributes "Term Attributes are properties passed to glossarify-md using an HTML comment syntax <!--{...}--> which encodes a JSON string: glossary.md"
+[4]: ./glossary.md#term-attribute "Term Attributes are properties passed to glossarify-md using an HTML comment syntax <!--{...}--> which encodes a JSON string: glossary.md"
 
 [5]: ./_references.md
 

--- a/doc/references.md
+++ b/doc/references.md
@@ -3,7 +3,7 @@
 In order to cite a source on the web whenever using a particular [term🟉][1], use a
 glossary configuration with `linkUris: true`:
 
-*[glossarify-md…][2].conf.json*
+*[glossarify-md][2].conf.json*
 
 ```json
 {
@@ -16,7 +16,7 @@ glossary configuration with `linkUris: true`:
 }
 ```
 
-Within file `./references.md` use the `uri` [term🟉][1] attribute to provide the source's [URL🟉][3]. Optionally you can add an `aliases` term attribute to make further terms refer to a particular source and provide a tooltip for the link.
+Within file `./references.md` use the `uri` [term🟉][1] attribute to provide the source's [URL🟉][3]. Optionally you can add an `aliases` [term attribute🟉][4] to make further terms refer to a particular source and provide a tooltip for the link.
 
 *references.md*
 
@@ -32,7 +32,7 @@ Within file `./references.md` use the `uri` [term🟉][1] attribute to provide t
 The Dublin Core Metadata Initiative.
 ```
 
-See an example by inspecting the markdown source of [\_references.md][4] or this repository's [glossarify-md.conf.json][5].
+See an example by inspecting the markdown source of [\_references.md][5] or this repository's [glossarify-md.conf.json][6].
 
 [1]: ./glossary.md#term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 
@@ -40,6 +40,8 @@ See an example by inspecting the markdown source of [\_references.md][4] or this
 
 [3]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[4]: ./_references.md
+[4]: ./glossary.md#term-attributes "Term Attributes are properties passed to glossarify-md using an HTML comment syntax <!--{...}--> which encodes a JSON string: glossary.md"
 
-[5]: ../glossarify-md.conf.json
+[5]: ./_references.md
+
+[6]: ../glossarify-md.conf.json

--- a/doc/skos-interop.md
+++ b/doc/skos-interop.md
@@ -1,18 +1,14 @@
 # [Interoperability with SKOS and JSON-LD](#interoperability-with-skos-and-json-ld)
 
-[glossarify-md][1]: [https://github.com/about-code/glossarify-md][2]
-\[doc-export-import]: ../README.md#structured-export-and-import
-\[headingidalgorithm]: ../README.md#headingidalgorithm
-[OWL][3]: [https://www.w3.org/TR/2012/REC-owl2-overview-20121211/][4]
-\[sample-export]: ../test/output-expected/config-glossaries/export-and-glossary-uri/glossary.json
+[doc-export-import]: ../README.md#structured-export-and-import
 
 > Readers Level: *Advanced*
 >
 > The term *term* can become itself confusing in this section. Therefore we'll say *model terms* if we refer to a vocabulary of technical attribute names or type names of a data model. We'll say *glossary terms* if we refer to the actual terms of a glossary (an instance of that data model).
 
-**Since v6.0.0** [glossarify-md][1] supports \[exporting and importing]\[doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" [SKOS][5] and [Dublin Core][6] model terms.
+**Since v6.0.0** [glossarify-md⎆][1] supports [exporting and importing][doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" [SKOS⎆][2] and [Dublin Core⎆][3] model terms.
 
-Model terms understood by [glossarify-md][1] are:
+Model terms understood by [glossarify-md⎆][1] are:
 
 *   `skos:ConceptScheme`
 *   `skos:Concept`
@@ -21,11 +17,11 @@ Model terms understood by [glossarify-md][1] are:
 *   `skos:definition`
 *   `dc:title`
 
-To see how this works a good starting point is to have a look at a [glossarify-md][1] `export` file first.
+To see how this works a good starting point is to have a look at a [glossarify-md⎆][1] `export` file first.
 
 ### [Exporting SKOS](#exporting-skos)
 
-*[glossarify-md][1].conf.json*
+*[glossarify-md⎆][1].conf.json*
 
 ```json
 {
@@ -39,7 +35,7 @@ To see how this works a good starting point is to have a look at a [glossarify-m
 }
 ```
 
-The configuration will make [glossarify-md][1] produce a file
+The configuration will make [glossarify-md⎆][1] produce a file
 
 *glossary.json*
 
@@ -81,9 +77,9 @@ The configuration will make [glossarify-md][1] produce a file
 }
 ```
 
-`glossary.json` will embed a \[JSON-LD] `@context` document. It maps [glossarify-md][1]'s own export model terminology onto [SKOS][5] and [Dublin Core][6] terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
+`glossary.json` will embed a \[JSON-LD] `@context` document. It maps [glossarify-md⎆][1]'s own export model terminology onto [SKOS⎆][2] and [Dublin Core⎆][3] terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
 
-[^1]: You can map [glossarify-md][1]'s terms onto other model [vocabularies🟉][7] by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
+[^1]: You can map [glossarify-md⎆][1]'s terms onto other model [vocabularies🟉][4] by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
 
 Next we'll simulate a roundtrip by importing our exported file again.
 
@@ -91,7 +87,7 @@ Next we'll simulate a roundtrip by importing our exported file again.
 
 Copy `glossary.json` which you've just exported into your input folder (*baseDir*) and change your config from `export` to `import`:
 
-*[glossarify-md][1].conf.json*
+*[glossarify-md⎆][1].conf.json*
 
 ```json
 {
@@ -104,7 +100,7 @@ Copy `glossary.json` which you've just exported into your input folder (*baseDir
 }
 ```
 
-Of course, [glossarify-md][1] will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
+Of course, [glossarify-md⎆][1] will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
 
 > In case you just ran glossarify-md and there is an `imported.md` file in your `outDir` then delete it.
 
@@ -129,11 +125,11 @@ Let's drop `@context` from `glossary.json` and change it to a very different sch
 }
 ```
 
-This is now a sample format *unknown* to [glossarify-md][1]. Different data formats and semantics like these are a barrier to *interoperability*. That's where [JSON-LD][8] and standardized [vocabularies🟉][7] enter the game.
+This is now a sample format *unknown* to [glossarify-md⎆][1]. Different data formats and semantics like these are a barrier to *interoperability*. That's where [JSON-LD⎆][5] and standardized [vocabularies🟉][4] enter the game.
 
-If the *unknown* application had embedded [JSON-LD][8] mappings onto [SKOS][5] and \[DublinCore] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
+If the *unknown* application had embedded [JSON-LD⎆][5] mappings onto [SKOS⎆][2] and \[DublinCore] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
 
-*unknown-format.[jsonld][9]*
+*unknown-format.[jsonld⎆][6]*
 
 ```json
 {
@@ -155,7 +151,7 @@ If the *unknown* application had embedded [JSON-LD][8] mappings onto [SKOS][5] a
 
 Now provide this *external context* document along the imported file:
 
-*[glossarify-md][1].conf.json*
+*[glossarify-md⎆][1].conf.json*
 
 ```json
 {
@@ -169,13 +165,13 @@ Now provide this *external context* document along the imported file:
 }
 ```
 
-What's left is to enhance [glossarify-md][1] with [JSON-LD][8] capabilities for interoperability: [^2]
+What's left is to enhance [glossarify-md⎆][1] with [JSON-LD⎆][5] capabilities for interoperability: [^2]
 
     npm install jsonld
 
-[^2]: We could have installed \[jsonld] together with [glossarify-md][1] by default but decided against to minimize bloat for the average user.
+[^2]: We could have installed \[jsonld] together with [glossarify-md⎆][1] by default but decided against to minimize bloat for the average user.
 
-On the next run [glossarify-md][1] will be looking for `@context` mappings
+On the next run [glossarify-md⎆][1] will be looking for `@context` mappings
 
 1.  *embedded into the JSON import file*
 2.  or provided *externally* using `context` in the `import` config.
@@ -186,24 +182,18 @@ To sum up: we've just seen an example of interoperability and how two or more ap
 
 ### [Additional Notes](#additional-notes)
 
-*   [glossarify-md][1] will only import typed documents directly using [JSON-LD][8]'s `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
+*   [glossarify-md⎆][1] will only import typed documents directly using [JSON-LD⎆][5]'s `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
 
-*   More complicated data formats may require use of some additional [JSON-LD][8] keywords from the JSON-LD Spec.
+*   More complicated data formats may require use of some additional [JSON-LD⎆][5] keywords from the JSON-LD Spec.
 
 [1]: https://github.com/about-code/glossarify-md "This project."
 
-[2]: https://github.com/about-code/glossarify-md
+[2]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
 
-[3]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/ "Web Ontology Language."
+[3]: http://purl.org/dc/terms/ "The Dublin Core Metadata Initiative."
 
-[4]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/
+[4]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
 
-[5]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
+[5]: https://json-ld.org "JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies."
 
-[6]: http://purl.org/dc/terms/ "The Dublin Core Metadata Initiative."
-
-[7]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
-
-[8]: https://json-ld.org "JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies."
-
-[9]: https://npmjs.com/package/jsonld "A JavaScript implementation of JSON-LD."
+[6]: https://npmjs.com/package/jsonld "A JavaScript implementation of JSON-LD."

--- a/doc/skos-interop.md
+++ b/doc/skos-interop.md
@@ -6,9 +6,9 @@
 >
 > The term *term* can become itself confusing in this section. Therefore we'll say *model terms* if we refer to a vocabulary of technical attribute names or type names of a data model. We'll say *glossary terms* if we refer to the actual terms of a glossary (an instance of that data model).
 
-**Since v6.0.0** [glossarify-md⎆][1] supports [exporting and importing][doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" [SKOS⎆][2] and [Dublin Core⎆][3] model terms.
+**Since v6.0.0** glossarify-md supports [exporting and importing][doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" SKOS and Dublin Core model terms.
 
-Model terms understood by [glossarify-md⎆][1] are:
+Model terms understood by glossarify-md are:
 
 *   `skos:ConceptScheme`
 *   `skos:Concept`
@@ -17,11 +17,11 @@ Model terms understood by [glossarify-md⎆][1] are:
 *   `skos:definition`
 *   `dc:title`
 
-To see how this works a good starting point is to have a look at a [glossarify-md⎆][1] `export` file first.
+To see how this works a good starting point is to have a look at a glossarify-md `export` file first.
 
 ### [Exporting SKOS](#exporting-skos)
 
-*[glossarify-md⎆][1].conf.json*
+*glossarify-md.conf.json*
 
 ```json
 {
@@ -35,7 +35,7 @@ To see how this works a good starting point is to have a look at a [glossarify-m
 }
 ```
 
-The configuration will make [glossarify-md⎆][1] produce a file
+The configuration will make glossarify-md produce a file
 
 *glossary.json*
 
@@ -77,9 +77,9 @@ The configuration will make [glossarify-md⎆][1] produce a file
 }
 ```
 
-`glossary.json` will embed a \[JSON-LD] `@context` document. It maps [glossarify-md⎆][1]'s own export model terminology onto [SKOS⎆][2] and [Dublin Core⎆][3] terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
+`glossary.json` will embed a \[JSON-LD] `@context` document. It maps glossarify-md's own export model terminology onto SKOS and Dublin Core terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
 
-[^1]: You can map [glossarify-md⎆][1]'s terms onto other model [vocabularies🟉][4] by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
+[^1]: You can map glossarify-md's terms onto other model [vocabularies🟉][1] by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
 
 Next we'll simulate a roundtrip by importing our exported file again.
 
@@ -87,7 +87,7 @@ Next we'll simulate a roundtrip by importing our exported file again.
 
 Copy `glossary.json` which you've just exported into your input folder (*baseDir*) and change your config from `export` to `import`:
 
-*[glossarify-md⎆][1].conf.json*
+*glossarify-md.conf.json*
 
 ```json
 {
@@ -100,7 +100,7 @@ Copy `glossary.json` which you've just exported into your input folder (*baseDir
 }
 ```
 
-Of course, [glossarify-md⎆][1] will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
+Of course, glossarify-md will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
 
 > In case you just ran glossarify-md and there is an `imported.md` file in your `outDir` then delete it.
 
@@ -125,11 +125,11 @@ Let's drop `@context` from `glossary.json` and change it to a very different sch
 }
 ```
 
-This is now a sample format *unknown* to [glossarify-md⎆][1]. Different data formats and semantics like these are a barrier to *interoperability*. That's where [JSON-LD⎆][5] and standardized [vocabularies🟉][4] enter the game.
+This is now a sample format *unknown* to glossarify-md. Different data formats and semantics like these are a barrier to *interoperability*. That's where JSON-LD and standardized [vocabularies🟉][1] enter the game.
 
-If the *unknown* application had embedded [JSON-LD⎆][5] mappings onto [SKOS⎆][2] and \[DublinCore] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
+If the *unknown* application had embedded JSON-LD mappings onto SKOS and \[DublinCore] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
 
-*unknown-format.[jsonld⎆][6]*
+*unknown-format.jsonld*
 
 ```json
 {
@@ -151,7 +151,7 @@ If the *unknown* application had embedded [JSON-LD⎆][5] mappings onto [SKOS⎆
 
 Now provide this *external context* document along the imported file:
 
-*[glossarify-md⎆][1].conf.json*
+*glossarify-md.conf.json*
 
 ```json
 {
@@ -165,13 +165,13 @@ Now provide this *external context* document along the imported file:
 }
 ```
 
-What's left is to enhance [glossarify-md⎆][1] with [JSON-LD⎆][5] capabilities for interoperability: [^2]
+What's left is to enhance glossarify-md with JSON-LD capabilities for interoperability: [^2]
 
     npm install jsonld
 
-[^2]: We could have installed \[jsonld] together with [glossarify-md⎆][1] by default but decided against to minimize bloat for the average user.
+[^2]: We could have installed \[jsonld] together with glossarify-md by default but decided against to minimize bloat for the average user.
 
-On the next run [glossarify-md⎆][1] will be looking for `@context` mappings
+On the next run glossarify-md will be looking for `@context` mappings
 
 1.  *embedded into the JSON import file*
 2.  or provided *externally* using `context` in the `import` config.
@@ -182,18 +182,8 @@ To sum up: we've just seen an example of interoperability and how two or more ap
 
 ### [Additional Notes](#additional-notes)
 
-*   [glossarify-md⎆][1] will only import typed documents directly using [JSON-LD⎆][5]'s `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
+*   glossarify-md will only import typed documents directly using JSON-LD's `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
 
-*   More complicated data formats may require use of some additional [JSON-LD⎆][5] keywords from the JSON-LD Spec.
+*   More complicated data formats may require use of some additional JSON-LD keywords from the JSON-LD Spec.
 
-[1]: https://github.com/about-code/glossarify-md "This project."
-
-[2]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
-
-[3]: http://purl.org/dc/terms/ "The Dublin Core Metadata Initiative."
-
-[4]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
-
-[5]: https://json-ld.org "JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies."
-
-[6]: https://npmjs.com/package/jsonld "A JavaScript implementation of JSON-LD."
+[1]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."

--- a/doc/skos-interop.md
+++ b/doc/skos-interop.md
@@ -6,9 +6,9 @@
 >
 > The term *term* can become itself confusing in this section. Therefore we'll say *model terms* if we refer to a vocabulary of technical attribute names or type names of a data model. We'll say *glossary terms* if we refer to the actual terms of a glossary (an instance of that data model).
 
-**Since v6.0.0** [glossarify-md…][1] supports [exporting and importing][doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" [SKOS…][2] and [Dublin Core…][3] model terms.
+**Since v6.0.0** [glossarify-md][1] supports [exporting and importing][doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" [SKOS][2] and [Dublin Core][3] model terms.
 
-Model terms understood by [glossarify-md…][1] are:
+Model terms understood by [glossarify-md][1] are:
 
 *   `skos:ConceptScheme`
 *   `skos:Concept`
@@ -17,11 +17,11 @@ Model terms understood by [glossarify-md…][1] are:
 *   `skos:definition`
 *   `dc:title`
 
-To see how this works a good starting point is to have a look at a [glossarify-md…][1] `export` file first.
+To see how this works a good starting point is to have a look at a [glossarify-md][1] `export` file first.
 
 ### [Exporting SKOS](#exporting-skos)
 
-*[glossarify-md…][1].conf.json*
+*[glossarify-md][1].conf.json*
 
 ```json
 {
@@ -35,7 +35,7 @@ To see how this works a good starting point is to have a look at a [glossarify-m
 }
 ```
 
-The configuration will make [glossarify-md…][1] produce a file
+The configuration will make [glossarify-md][1] produce a file
 
 *glossary.json*
 
@@ -77,9 +77,9 @@ The configuration will make [glossarify-md…][1] produce a file
 }
 ```
 
-`glossary.json` will embed a \[JSON-LD] `@context` document. It maps [glossarify-md…][1]'s own export model terminology onto [SKOS…][2] and [Dublin Core…][3] terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
+`glossary.json` will embed a \[JSON-LD] `@context` document. It maps [glossarify-md][1]'s own export model terminology onto [SKOS][2] and [Dublin Core][3] terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
 
-[^1]: You can map [glossarify-md…][1]'s terms onto other model [vocabularies🟉][4] by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
+[^1]: You can map [glossarify-md][1]'s terms onto other model [vocabularies🟉][4] by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
 
 Next we'll simulate a roundtrip by importing our exported file again.
 
@@ -87,7 +87,7 @@ Next we'll simulate a roundtrip by importing our exported file again.
 
 Copy `glossary.json` which you've just exported into your input folder (*baseDir*) and change your config from `export` to `import`:
 
-*[glossarify-md…][1].conf.json*
+*[glossarify-md][1].conf.json*
 
 ```json
 {
@@ -100,7 +100,7 @@ Copy `glossary.json` which you've just exported into your input folder (*baseDir
 }
 ```
 
-Of course, [glossarify-md…][1] will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
+Of course, [glossarify-md][1] will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
 
 > In case you just ran glossarify-md and there is an `imported.md` file in your `outDir` then delete it.
 
@@ -125,11 +125,11 @@ Let's drop `@context` from `glossary.json` and change it to a very different sch
 }
 ```
 
-This is now a sample format *unknown* to [glossarify-md…][1]. Different data formats and semantics like these are a barrier to *interoperability*. That's where [JSON-LD…][5] and standardized [vocabularies🟉][4] enter the game.
+This is now a sample format *unknown* to [glossarify-md][1]. Different data formats and semantics like these are a barrier to *interoperability*. That's where [JSON-LD][5] and standardized [vocabularies🟉][4] enter the game.
 
-If the *unknown* application had embedded [JSON-LD…][5] mappings onto [SKOS…][2] and \[DublinCore] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
+If the *unknown* application had embedded [JSON-LD][5] mappings onto [SKOS][2] and \[DublinCore] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
 
-*unknown-format.[jsonld…][6]*
+*unknown-format.[jsonld][6]*
 
 ```json
 {
@@ -151,7 +151,7 @@ If the *unknown* application had embedded [JSON-LD…][5] mappings onto [SKOS…
 
 Now provide this *external context* document along the imported file:
 
-*[glossarify-md…][1].conf.json*
+*[glossarify-md][1].conf.json*
 
 ```json
 {
@@ -165,13 +165,13 @@ Now provide this *external context* document along the imported file:
 }
 ```
 
-What's left is to enhance [glossarify-md…][1] with [JSON-LD…][5] capabilities for interoperability: [^2]
+What's left is to enhance [glossarify-md][1] with [JSON-LD][5] capabilities for interoperability: [^2]
 
     npm install jsonld
 
-[^2]: We could have installed \[jsonld] together with [glossarify-md…][1] by default but decided against to minimize bloat for the average user.
+[^2]: We could have installed \[jsonld] together with [glossarify-md][1] by default but decided against to minimize bloat for the average user.
 
-On the next run [glossarify-md…][1] will be looking for `@context` mappings
+On the next run [glossarify-md][1] will be looking for `@context` mappings
 
 1.  *embedded into the JSON import file*
 2.  or provided *externally* using `context` in the `import` config.
@@ -182,9 +182,9 @@ To sum up: we've just seen an example of interoperability and how two or more ap
 
 ### [Additional Notes](#additional-notes)
 
-*   [glossarify-md…][1] will only import typed documents directly using [JSON-LD…][5]'s `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
+*   [glossarify-md][1] will only import typed documents directly using [JSON-LD][5]'s `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
 
-*   More complicated data formats may require use of some additional [JSON-LD…][5] keywords from the JSON-LD Spec.
+*   More complicated data formats may require use of some additional [JSON-LD][5] keywords from the JSON-LD Spec.
 
 [1]: https://github.com/about-code/glossarify-md "This project."
 

--- a/doc/skos-interop.md
+++ b/doc/skos-interop.md
@@ -6,9 +6,9 @@
 >
 > The term *term* can become itself confusing in this section. Therefore we'll say *model terms* if we refer to a vocabulary of technical attribute names or type names of a data model. We'll say *glossary terms* if we refer to the actual terms of a glossary (an instance of that data model).
 
-**Since v6.0.0** glossarify-md supports [exporting and importing][doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" SKOS and Dublin Core model terms.
+**Since v6.0.0** [glossarify-md…][1] supports [exporting and importing][doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" [SKOS…][2] and [Dublin Core…][3] model terms.
 
-Model terms understood by glossarify-md are:
+Model terms understood by [glossarify-md…][1] are:
 
 *   `skos:ConceptScheme`
 *   `skos:Concept`
@@ -17,11 +17,11 @@ Model terms understood by glossarify-md are:
 *   `skos:definition`
 *   `dc:title`
 
-To see how this works a good starting point is to have a look at a glossarify-md `export` file first.
+To see how this works a good starting point is to have a look at a [glossarify-md…][1] `export` file first.
 
 ### [Exporting SKOS](#exporting-skos)
 
-*glossarify-md.conf.json*
+*[glossarify-md…][1].conf.json*
 
 ```json
 {
@@ -35,7 +35,7 @@ To see how this works a good starting point is to have a look at a glossarify-md
 }
 ```
 
-The configuration will make glossarify-md produce a file
+The configuration will make [glossarify-md…][1] produce a file
 
 *glossary.json*
 
@@ -77,9 +77,9 @@ The configuration will make glossarify-md produce a file
 }
 ```
 
-`glossary.json` will embed a \[JSON-LD] `@context` document. It maps glossarify-md's own export model terminology onto SKOS and Dublin Core terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
+`glossary.json` will embed a \[JSON-LD] `@context` document. It maps [glossarify-md…][1]'s own export model terminology onto [SKOS…][2] and [Dublin Core…][3] terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
 
-[^1]: You can map glossarify-md's terms onto other model [vocabularies🟉][1] by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
+[^1]: You can map [glossarify-md…][1]'s terms onto other model [vocabularies🟉][4] by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
 
 Next we'll simulate a roundtrip by importing our exported file again.
 
@@ -87,7 +87,7 @@ Next we'll simulate a roundtrip by importing our exported file again.
 
 Copy `glossary.json` which you've just exported into your input folder (*baseDir*) and change your config from `export` to `import`:
 
-*glossarify-md.conf.json*
+*[glossarify-md…][1].conf.json*
 
 ```json
 {
@@ -100,7 +100,7 @@ Copy `glossary.json` which you've just exported into your input folder (*baseDir
 }
 ```
 
-Of course, glossarify-md will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
+Of course, [glossarify-md…][1] will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
 
 > In case you just ran glossarify-md and there is an `imported.md` file in your `outDir` then delete it.
 
@@ -125,11 +125,11 @@ Let's drop `@context` from `glossary.json` and change it to a very different sch
 }
 ```
 
-This is now a sample format *unknown* to glossarify-md. Different data formats and semantics like these are a barrier to *interoperability*. That's where JSON-LD and standardized [vocabularies🟉][1] enter the game.
+This is now a sample format *unknown* to [glossarify-md…][1]. Different data formats and semantics like these are a barrier to *interoperability*. That's where [JSON-LD…][5] and standardized [vocabularies🟉][4] enter the game.
 
-If the *unknown* application had embedded JSON-LD mappings onto SKOS and \[DublinCore] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
+If the *unknown* application had embedded [JSON-LD…][5] mappings onto [SKOS…][2] and \[DublinCore] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
 
-*unknown-format.jsonld*
+*unknown-format.[jsonld…][6]*
 
 ```json
 {
@@ -151,7 +151,7 @@ If the *unknown* application had embedded JSON-LD mappings onto SKOS and \[Dubli
 
 Now provide this *external context* document along the imported file:
 
-*glossarify-md.conf.json*
+*[glossarify-md…][1].conf.json*
 
 ```json
 {
@@ -165,13 +165,13 @@ Now provide this *external context* document along the imported file:
 }
 ```
 
-What's left is to enhance glossarify-md with JSON-LD capabilities for interoperability: [^2]
+What's left is to enhance [glossarify-md…][1] with [JSON-LD…][5] capabilities for interoperability: [^2]
 
     npm install jsonld
 
-[^2]: We could have installed \[jsonld] together with glossarify-md by default but decided against to minimize bloat for the average user.
+[^2]: We could have installed \[jsonld] together with [glossarify-md…][1] by default but decided against to minimize bloat for the average user.
 
-On the next run glossarify-md will be looking for `@context` mappings
+On the next run [glossarify-md…][1] will be looking for `@context` mappings
 
 1.  *embedded into the JSON import file*
 2.  or provided *externally* using `context` in the `import` config.
@@ -182,8 +182,18 @@ To sum up: we've just seen an example of interoperability and how two or more ap
 
 ### [Additional Notes](#additional-notes)
 
-*   glossarify-md will only import typed documents directly using JSON-LD's `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
+*   [glossarify-md…][1] will only import typed documents directly using [JSON-LD…][5]'s `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
 
-*   More complicated data formats may require use of some additional JSON-LD keywords from the JSON-LD Spec.
+*   More complicated data formats may require use of some additional [JSON-LD…][5] keywords from the JSON-LD Spec.
 
-[1]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
+[1]: https://github.com/about-code/glossarify-md "This project."
+
+[2]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
+
+[3]: http://purl.org/dc/terms/ "The Dublin Core Metadata Initiative."
+
+[4]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
+
+[5]: https://json-ld.org "JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies."
+
+[6]: https://npmjs.com/package/jsonld "A JavaScript implementation of JSON-LD."

--- a/doc/skos-interop.md
+++ b/doc/skos-interop.md
@@ -1,36 +1,18 @@
 # [Interoperability with SKOS and JSON-LD](#interoperability-with-skos-and-json-ld)
 
-[glossarify-md]: https://github.com/about-code/glossarify-md
-
-[doc-export-import]: ../README.md#structured-export-and-import
-
-[headingidalgorithm]: ../README.md#headingidalgorithm
-
-[SKOS]: http://w3.org/skos/
-
-[DC]: http://purl.org/dc/terms/
-
-[LD]: https://www.w3.org/standards/semanticweb/ontology
-
-[JSON-LD]: https://json-ld.org
-
-[JSON-LD Spec]: https://www.w3.org/TR/json-ld/
-
-[jsonld]: https://npmjs.com/package/jsonld
-
-[vocabularies]: https://www.w3.org/standards/semanticweb/ontology
-
-[OWL]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/
-
-[sample-export]: ../test/output-expected/config-glossaries/export-and-glossary-uri/glossary.json
+[glossarify-md][1]: [https://github.com/about-code/glossarify-md][2]
+\[doc-export-import]: ../README.md#structured-export-and-import
+\[headingidalgorithm]: ../README.md#headingidalgorithm
+[OWL][3]: [https://www.w3.org/TR/2012/REC-owl2-overview-20121211/][4]
+\[sample-export]: ../test/output-expected/config-glossaries/export-and-glossary-uri/glossary.json
 
 > Readers Level: *Advanced*
 >
 > The term *term* can become itself confusing in this section. Therefore we'll say *model terms* if we refer to a vocabulary of technical attribute names or type names of a data model. We'll say *glossary terms* if we refer to the actual terms of a glossary (an instance of that data model).
 
-**Since v6.0.0** [glossarify-md] supports [exporting and importing][doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" [SKOS] and [Dublin Core][DC] model terms.
+**Since v6.0.0** [glossarify-md][1] supports \[exporting and importing]\[doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" [SKOS][5] and [Dublin Core][6] model terms.
 
-Model terms understood by [glossarify-md] are:
+Model terms understood by [glossarify-md][1] are:
 
 *   `skos:ConceptScheme`
 *   `skos:Concept`
@@ -39,11 +21,11 @@ Model terms understood by [glossarify-md] are:
 *   `skos:definition`
 *   `dc:title`
 
-To see how this works a good starting point is to have a look at a glossarify-md `export` file first.
+To see how this works a good starting point is to have a look at a [glossarify-md][1] `export` file first.
 
 ### [Exporting SKOS](#exporting-skos)
 
-*glossarify-md.conf.json*
+*[glossarify-md][1].conf.json*
 
 ```json
 {
@@ -57,7 +39,7 @@ To see how this works a good starting point is to have a look at a glossarify-md
 }
 ```
 
-The configuration will make [glossarify-md] produce a file
+The configuration will make [glossarify-md][1] produce a file
 
 *glossary.json*
 
@@ -99,9 +81,9 @@ The configuration will make [glossarify-md] produce a file
 }
 ```
 
-`glossary.json` will embed a [JSON-LD] `@context` document. It maps glossarify-md's own export model terminology onto [SKOS] and [Dublin Core][DC] terms for interoperability with *other* tools understanding [SKOS🟉][1] and Dublin Core.[^1]
+`glossary.json` will embed a \[JSON-LD] `@context` document. It maps [glossarify-md][1]'s own export model terminology onto [SKOS][5] and [Dublin Core][6] terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
 
-[^1]: You can map glossarify-md's terms onto other model vocabularies by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
+[^1]: You can map [glossarify-md][1]'s terms onto other model [vocabularies🟉][7] by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
 
 Next we'll simulate a roundtrip by importing our exported file again.
 
@@ -109,7 +91,7 @@ Next we'll simulate a roundtrip by importing our exported file again.
 
 Copy `glossary.json` which you've just exported into your input folder (*baseDir*) and change your config from `export` to `import`:
 
-*glossarify-md.conf.json*
+*[glossarify-md][1].conf.json*
 
 ```json
 {
@@ -122,9 +104,9 @@ Copy `glossary.json` which you've just exported into your input folder (*baseDir
 }
 ```
 
-Of course, [glossarify-md] will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
+Of course, [glossarify-md][1] will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
 
-> In case you just ran [glossarify-md] and there is an `imported.md` file in your `outDir` then delete it.
+> In case you just ran glossarify-md and there is an `imported.md` file in your `outDir` then delete it.
 
 Let's drop `@context` from `glossary.json` and change it to a very different schema:
 
@@ -147,11 +129,11 @@ Let's drop `@context` from `glossary.json` and change it to a very different sch
 }
 ```
 
-This is now a sample format *unknown* to [glossarify-md]. Different data formats and semantics like these are a barrier to *interoperability*. That's where [JSON-LD🟉][2] and standardized vocabularies enter the game.
+This is now a sample format *unknown* to [glossarify-md][1]. Different data formats and semantics like these are a barrier to *interoperability*. That's where [JSON-LD][8] and standardized [vocabularies🟉][7] enter the game.
 
-If the *unknown* application had embedded [JSON-LD🟉][2] mappings onto [SKOS] and [DublinCore][DC] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
+If the *unknown* application had embedded [JSON-LD][8] mappings onto [SKOS][5] and \[DublinCore] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
 
-*unknown-format.jsonld*
+*unknown-format.[jsonld][9]*
 
 ```json
 {
@@ -173,7 +155,7 @@ If the *unknown* application had embedded [JSON-LD🟉][2] mappings onto [SKOS] 
 
 Now provide this *external context* document along the imported file:
 
-*glossarify-md.conf.json*
+*[glossarify-md][1].conf.json*
 
 ```json
 {
@@ -187,13 +169,13 @@ Now provide this *external context* document along the imported file:
 }
 ```
 
-What's left is to enhance glossarify-md with [JSON-LD🟉][2] capabilities for interoperability: [^2]
+What's left is to enhance [glossarify-md][1] with [JSON-LD][8] capabilities for interoperability: [^2]
 
     npm install jsonld
 
-[^2]: We could have installed [jsonld] together with [glossarify-md] by default but decided against to minimize bloat for the average user.
+[^2]: We could have installed \[jsonld] together with [glossarify-md][1] by default but decided against to minimize bloat for the average user.
 
-On the next run [glossarify-md] will be looking for `@context` mappings
+On the next run [glossarify-md][1] will be looking for `@context` mappings
 
 1.  *embedded into the JSON import file*
 2.  or provided *externally* using `context` in the `import` config.
@@ -204,10 +186,24 @@ To sum up: we've just seen an example of interoperability and how two or more ap
 
 ### [Additional Notes](#additional-notes)
 
-*   [glossarify-md] will only import typed documents directly using [JSON-LD🟉][2]'s `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
+*   [glossarify-md][1] will only import typed documents directly using [JSON-LD][8]'s `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
 
-*   More complicated data formats may require use of some additional [JSON-LD keywords][JSON-LD Spec].
+*   More complicated data formats may require use of some additional [JSON-LD][8] keywords from the JSON-LD Spec.
 
-[1]: ./glossary.md#skos "With SKOS the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
+[1]: https://github.com/about-code/glossarify-md "This project."
 
-[2]: ./glossary.md#json-ld "JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies."
+[2]: https://github.com/about-code/glossarify-md
+
+[3]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/ "Web Ontology Language."
+
+[4]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/
+
+[5]: http://w3.org/skos/ "With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling Simple Knowledge Organization Systems such as Glossaries, Thesauri, Taxonomies or Word Nets."
+
+[6]: http://purl.org/dc/terms/ "The Dublin Core Metadata Initiative."
+
+[7]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
+
+[8]: https://json-ld.org "JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies."
+
+[9]: https://npmjs.com/package/jsonld "A JavaScript implementation of JSON-LD."

--- a/doc/vocabulary-uris.md
+++ b/doc/vocabulary-uris.md
@@ -16,7 +16,7 @@ it is clear that it refers to a different meaning than some identifier
 
 *   `https://example.com/glossary/it/#security`.
 
-**Since v6.0.0** [glossarify-md…][3] supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *[vocabulary🟉][4] [URI🟉][2]*. Then *exported* [term🟉][1] URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingIdAlgorithm]).
+**Since v6.0.0** [glossarify-md][3] supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *[vocabulary🟉][4] [URI🟉][2]*. Then *exported* [term🟉][1] URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingIdAlgorithm]).
 
 ```json
 {
@@ -30,7 +30,7 @@ it is clear that it refers to a different meaning than some identifier
 }
 ```
 
-If you need more control about a [term🟉][1]'s [URI🟉][2] then explicit heading IDs can be assigned using pandoc-style `{#headingId}` or the `uri` *term attribute*:
+If you need more control about a [term🟉][1]'s [URI🟉][2] then explicit heading IDs can be assigned using pandoc-style `{#headingId}` or the `uri` *[term attribute🟉][5]*:
 
 *glossary.md*
 
@@ -47,7 +47,7 @@ Term with an individual URI.
 
 ### [Resolvability](#resolvability)
 
-URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a [term🟉][1]'s [URI🟉][2] could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make [glossarify-md…][3] link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
+URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a [term🟉][1]'s [URI🟉][2] could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make [glossarify-md][3] link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
 
 ### [Authority](#authority)
 
@@ -69,7 +69,7 @@ urn:uuid:b3c38d70-3887-11ec-a63d-779a5e093fff
 ~~~
 -->
 
-If you have a background in [Linked Data…][5] and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][doc-skos].
+If you have a background in [Linked Data][6] and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][doc-skos].
 
 [1]: ./glossary.md#term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 
@@ -79,4 +79,6 @@ If you have a background in [Linked Data…][5] and Semantic Web technologies yo
 
 [4]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
 
-[5]: https://www.w3.org/standards/semanticweb/ontology "See Linked Data."
+[5]: ./glossary.md#term-attributes "Term Attributes are properties passed to glossarify-md using an HTML comment syntax <!--{...}--> which encodes a JSON string: glossary.md"
+
+[6]: https://www.w3.org/standards/semanticweb/ontology "See Linked Data."

--- a/doc/vocabulary-uris.md
+++ b/doc/vocabulary-uris.md
@@ -16,7 +16,7 @@ it is clear that it refers to a different meaning than some identifier
 
 *   `https://example.com/glossary/it/#security`.
 
-**Since v6.0.0** [glossarify-md][3] supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *[vocabulary🟉][4] [URI🟉][2]*. Then *exported* [term🟉][1] URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingIdAlgorithm]).
+**Since v6.0.0** [glossarify-md⎆][3] supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *[vocabulary🟉][4] [URI🟉][2]*. Then *exported* [term🟉][1] URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingIdAlgorithm]).
 
 ```json
 {
@@ -47,7 +47,7 @@ Term with an individual URI.
 
 ### [Resolvability](#resolvability)
 
-URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a [term🟉][1]'s [URI🟉][2] could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make [glossarify-md][3] link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
+URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a [term🟉][1]'s [URI🟉][2] could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make [glossarify-md⎆][3] link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
 
 ### [Authority](#authority)
 
@@ -69,7 +69,7 @@ urn:uuid:b3c38d70-3887-11ec-a63d-779a5e093fff
 ~~~
 -->
 
-If you have a background in [Linked Data][5] and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][doc-skos].
+If you have a background in [Linked Data⎆][5] and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][doc-skos].
 
 [1]: ./glossary.md#term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 

--- a/doc/vocabulary-uris.md
+++ b/doc/vocabulary-uris.md
@@ -79,6 +79,6 @@ If you have a background in [Linked Data][6] and Semantic Web technologies you m
 
 [4]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
 
-[5]: ./glossary.md#term-attributes "Term Attributes are properties passed to glossarify-md using an HTML comment syntax <!--{...}--> which encodes a JSON string: glossary.md"
+[5]: ./glossary.md#term-attribute "Term Attributes are properties passed to glossarify-md using an HTML comment syntax <!--{...}--> which encodes a JSON string: glossary.md"
 
 [6]: https://www.w3.org/standards/semanticweb/ontology "See Linked Data."

--- a/doc/vocabulary-uris.md
+++ b/doc/vocabulary-uris.md
@@ -1,16 +1,14 @@
 # [URIs as Identifiers for *Definitions of Meaning*](#uris-as-identifiers-for-definitions-of-meaning)
 
-[glossarify-md]: https://github.com/about-code/glossarify-md/
-
-[headingidalgorithm]: ../README.md#headingidalgorithm
-
-[iana-urns]: https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml
+[headingIdAlgorithm]: ../README.md#headingidalgorithm
 
 [doc-import]: ../README.md#structured-export-and-import
 
-Consider bankers and IT professionals talking about *security*. Since the term is used differently in the banking domain than it is being used in computer science its *ambiguity* can cause some confusion among these people. As a consequence the term demands *clarification* of its particular meaning when being used. Of course, that's what glossaries are meant for.
+[doc-skos]: ./skos-interop.md
 
-*For a computer* such kind of clarification can be achieved using *IDs* to *uniquely identify one particular definition of meaning*. Uniform Resource Identifiers (URIs) do fit well for that purpose. For example whenever a system processes an [URI🟉][1]
+Consider bankers and IT professionals talking about *security*. Since the [term🟉][1] is used differently in the banking domain than it is being used in computer science its *ambiguity* can cause some confusion among these people. As a consequence the term demands *clarification* of its particular meaning when being used. Of course, that's what glossaries are meant for.
+
+*For a computer* such kind of clarification can be achieved using *IDs* to *uniquely identify one particular definition of meaning*. Uniform Resource Identifiers (URIs) do fit well for that purpose. For example whenever a system processes an [URI🟉][2]
 
 *   `https://example.com/glossary/banking/#security`
 
@@ -18,7 +16,7 @@ it is clear that it refers to a different meaning than some identifier
 
 *   `https://example.com/glossary/it/#security`.
 
-**Since v6.0.0** [glossarify-md] supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *vocabulary [URI🟉][1]*. Then *exported* term URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingidalgorithm]).
+**Since v6.0.0** [glossarify-md][3] supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *[vocabulary🟉][4] [URI🟉][2]*. Then *exported* [term🟉][1] URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingIdAlgorithm]).
 
 ```json
 {
@@ -32,7 +30,7 @@ it is clear that it refers to a different meaning than some identifier
 }
 ```
 
-If you need more control about a term's [URI🟉][1] then explicit heading IDs can be assigned using pandoc-style `{#headingId}` or the `uri` *term attribute*:
+If you need more control about a [term🟉][1]'s [URI🟉][2] then explicit heading IDs can be assigned using pandoc-style `{#headingId}` or the `uri` *term attribute*:
 
 *glossary.md*
 
@@ -49,14 +47,14 @@ Term with an individual URI.
 
 ### [Resolvability](#resolvability)
 
-URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a term's [URI🟉][1] could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make [glossarify-md] link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
+URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a [term🟉][1]'s [URI🟉][2] could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make [glossarify-md][3] link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
 
 ### [Authority](#authority)
 
-URIs for terms reveal the authoritative source for a particular definition, which in our example was `example.com`. While anyone could use any domain name in an [URI🟉][1] and make it the identifier of something (like we did here) only the legitimate domain name owner as registered in the Domain Name System (DNS) can claim authority in case of disputes over some definition. So in this particular example we could *not* veto if the owners of domain `example.com` chose to use above URIs to identify something else. By using another domain name than our own we effectively accept that there could be conflicting definitions wiping out the purpose of an URI. So particularly when publishing a vocabulary it is usually not a good idea to do so.
+URIs for terms reveal the authoritative source for a particular definition, which in our example was `example.com`. While anyone could use any domain name in an [URI🟉][2] and make it the identifier of something (like we did here) only the legitimate domain name owner as registered in the Domain Name System (DNS) can claim authority in case of disputes over some definition. So in this particular example we could *not* veto if the owners of domain `example.com` chose to use above URIs to identify something else. By using another domain name than our own we effectively accept that there could be conflicting definitions wiping out the purpose of an URI. So particularly when publishing a [vocabulary🟉][4] it is usually not a good idea to do so.
 
 <!--
-Uniform Resource Names (URNs) may be an alternative to URIs. They do not depend on the Domain Name System as a registry but on an [IANA registry of *URN namespaces*][iana-urns]:
+Uniform Resource Names (URNs) may be an alternative to URIs. They do not depend on the Domain Name System as a registry but on an IANA registry of *URN namespaces*:
 
 *URN with the `isbn` namespace registered by the International ISBN Agency*
 ~~~
@@ -71,8 +69,14 @@ urn:uuid:b3c38d70-3887-11ec-a63d-779a5e093fff
 ~~~
 -->
 
-If you have a background in Linked Data and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][2].
+If you have a background in [Linked Data][5] and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][doc-skos].
 
-[1]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+[1]: ./glossary.md#term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 
-[2]: ./skos-interop.md
+[2]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+
+[3]: https://github.com/about-code/glossarify-md "This project."
+
+[4]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
+
+[5]: https://www.w3.org/standards/semanticweb/ontology "See Linked Data."

--- a/doc/vocabulary-uris.md
+++ b/doc/vocabulary-uris.md
@@ -16,7 +16,7 @@ it is clear that it refers to a different meaning than some identifier
 
 *   `https://example.com/glossary/it/#security`.
 
-**Since v6.0.0** glossarify-md supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *[vocabulary🟉][3] [URI🟉][2]*. Then *exported* [term🟉][1] URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingIdAlgorithm]).
+**Since v6.0.0** [glossarify-md…][3] supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *[vocabulary🟉][4] [URI🟉][2]*. Then *exported* [term🟉][1] URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingIdAlgorithm]).
 
 ```json
 {
@@ -47,11 +47,11 @@ Term with an individual URI.
 
 ### [Resolvability](#resolvability)
 
-URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a [term🟉][1]'s [URI🟉][2] could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make glossarify-md link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
+URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a [term🟉][1]'s [URI🟉][2] could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make [glossarify-md…][3] link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
 
 ### [Authority](#authority)
 
-URIs for terms reveal the authoritative source for a particular definition, which in our example was `example.com`. While anyone could use any domain name in an [URI🟉][2] and make it the identifier of something (like we did here) only the legitimate domain name owner as registered in the Domain Name System (DNS) can claim authority in case of disputes over some definition. So in this particular example we could *not* veto if the owners of domain `example.com` chose to use above URIs to identify something else. By using another domain name than our own we effectively accept that there could be conflicting definitions wiping out the purpose of an URI. So particularly when publishing a [vocabulary🟉][3] it is usually not a good idea to do so.
+URIs for terms reveal the authoritative source for a particular definition, which in our example was `example.com`. While anyone could use any domain name in an [URI🟉][2] and make it the identifier of something (like we did here) only the legitimate domain name owner as registered in the Domain Name System (DNS) can claim authority in case of disputes over some definition. So in this particular example we could *not* veto if the owners of domain `example.com` chose to use above URIs to identify something else. By using another domain name than our own we effectively accept that there could be conflicting definitions wiping out the purpose of an URI. So particularly when publishing a [vocabulary🟉][4] it is usually not a good idea to do so.
 
 <!--
 Uniform Resource Names (URNs) may be an alternative to URIs. They do not depend on the Domain Name System as a registry but on an IANA registry of *URN namespaces*:
@@ -69,10 +69,14 @@ urn:uuid:b3c38d70-3887-11ec-a63d-779a5e093fff
 ~~~
 -->
 
-If you have a background in Linked Data and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][doc-skos].
+If you have a background in [Linked Data…][5] and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][doc-skos].
 
 [1]: ./glossary.md#term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 
 [2]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[3]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
+[3]: https://github.com/about-code/glossarify-md "This project."
+
+[4]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
+
+[5]: https://www.w3.org/standards/semanticweb/ontology "See Linked Data."

--- a/doc/vocabulary-uris.md
+++ b/doc/vocabulary-uris.md
@@ -16,7 +16,7 @@ it is clear that it refers to a different meaning than some identifier
 
 *   `https://example.com/glossary/it/#security`.
 
-**Since v6.0.0** [glossarify-md⎆][3] supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *[vocabulary🟉][4] [URI🟉][2]*. Then *exported* [term🟉][1] URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingIdAlgorithm]).
+**Since v6.0.0** glossarify-md supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *[vocabulary🟉][3] [URI🟉][2]*. Then *exported* [term🟉][1] URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingIdAlgorithm]).
 
 ```json
 {
@@ -47,11 +47,11 @@ Term with an individual URI.
 
 ### [Resolvability](#resolvability)
 
-URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a [term🟉][1]'s [URI🟉][2] could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make [glossarify-md⎆][3] link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
+URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a [term🟉][1]'s [URI🟉][2] could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make glossarify-md link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
 
 ### [Authority](#authority)
 
-URIs for terms reveal the authoritative source for a particular definition, which in our example was `example.com`. While anyone could use any domain name in an [URI🟉][2] and make it the identifier of something (like we did here) only the legitimate domain name owner as registered in the Domain Name System (DNS) can claim authority in case of disputes over some definition. So in this particular example we could *not* veto if the owners of domain `example.com` chose to use above URIs to identify something else. By using another domain name than our own we effectively accept that there could be conflicting definitions wiping out the purpose of an URI. So particularly when publishing a [vocabulary🟉][4] it is usually not a good idea to do so.
+URIs for terms reveal the authoritative source for a particular definition, which in our example was `example.com`. While anyone could use any domain name in an [URI🟉][2] and make it the identifier of something (like we did here) only the legitimate domain name owner as registered in the Domain Name System (DNS) can claim authority in case of disputes over some definition. So in this particular example we could *not* veto if the owners of domain `example.com` chose to use above URIs to identify something else. By using another domain name than our own we effectively accept that there could be conflicting definitions wiping out the purpose of an URI. So particularly when publishing a [vocabulary🟉][3] it is usually not a good idea to do so.
 
 <!--
 Uniform Resource Names (URNs) may be an alternative to URIs. They do not depend on the Domain Name System as a registry but on an IANA registry of *URN namespaces*:
@@ -69,14 +69,10 @@ urn:uuid:b3c38d70-3887-11ec-a63d-779a5e093fff
 ~~~
 -->
 
-If you have a background in [Linked Data⎆][5] and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][doc-skos].
+If you have a background in Linked Data and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][doc-skos].
 
 [1]: ./glossary.md#term "A term is a heading in a markdown file which is passed to glossarify-md as a glossary."
 
 [2]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[3]: https://github.com/about-code/glossarify-md "This project."
-
-[4]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."
-
-[5]: https://www.w3.org/standards/semanticweb/ontology "See Linked Data."
+[3]: ./glossary.md#vocabulary "A collection of terms which is uniquely identifiable."

--- a/doc/vuepress.md
+++ b/doc/vuepress.md
@@ -31,7 +31,7 @@ Below we assume a *sample* project structure like this:
 
 ## [Configure glossarify-md](#configure-glossarify-md)
 
-*[glossarify-md⎆][1].conf.json*
+*glossarify-md.conf.json*
 
 ```json
 {
@@ -48,7 +48,7 @@ Below we assume a *sample* project structure like this:
 
 ## [Configure vuepress](#configure-vuepress)
 
-[glossarify-md⎆][1] and [vuepress⎆][2] need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix][3].
+glossarify-md and vuepress need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix][1].
 
 <em>./docs/.vuepress/config.js</em>
 
@@ -89,23 +89,23 @@ module.exports = {
 *   `npm start` builds and serves files quickly from `baseDir` with *live-reload*. This is what you probably want while writing even though it doesn't produce glossarified output.
 *   `npm run glossarify` writes glossarified markdown files to `outDir`
 *   `npm run glossarified` builds and serves the glossarified version from `outDir`.
-*   `npm run build` just builds the glossarified [vuepress⎆][2] site without running a server.
+*   `npm run build` just builds the glossarified vuepress site without running a server.
 
-More information see [README.md][4].
+More information see [README.md][2].
 
 ## [Markdown Extensions](#markdown-extensions)
 
-[Vuepress⎆][2] supports some [Markdown Syntax][5] not covered by [CommonMark⎆][6]. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with [glossarify-md⎆][1] (see [Markdown Syntax Extensions][doc-syntax-extensions]).
+Vuepress supports some [Markdown Syntax][3] not covered by CommonMark. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with glossarify-md (see [Markdown Syntax Extensions][doc-syntax-extensions]).
 
-| [Vuepress⎆][2] Markdown Extension     | [remark⎆][7] plug-in required with [glossarify-md⎆][1] |
-| ------------------------------------- | ------------------------------------------------------ |
-| [Frontmatter][vp-frontmatter]         | [remark-frontmatter][8]                                |
-| [Custom Containers][vp-cc]            | None                                                   |
-| [GitHub Style Tables][vp-gh-tables]   | None                                                   |
-| [Table of Contents][vp-toc] `[[toc]]` | None                                                   |
-| [Emoji][vp-emoji]                     | None                                                   |
-| [Line Highlighting Codeblocks][vp-lh] | None                                                   |
-| [Import Code Snippets][vp-code]       | None                                                   |
+| Vuepress Markdown Extension           | remark plug-in required with glossarify-md |
+| ------------------------------------- | ------------------------------------------ |
+| [Frontmatter][vp-frontmatter]         | [remark-frontmatter][4]                    |
+| [Custom Containers][vp-cc]            | None                                       |
+| [GitHub Style Tables][vp-gh-tables]   | None                                       |
+| [Table of Contents][vp-toc] `[[toc]]` | None                                       |
+| [Emoji][vp-emoji]                     | None                                       |
+| [Line Highlighting Codeblocks][vp-lh] | None                                       |
+| [Import Code Snippets][vp-code]       | None                                       |
 
 [vp-frontmatter]: https://vuepress.vuejs.org/guide/markdown.html#frontmatter
 
@@ -123,11 +123,11 @@ More information see [README.md][4].
 
 ## [Appendix](#appendix)
 
-[glossarify-md⎆][1] and [vuepress⎆][2] both employ a [slug🟉][9] algorithm to create friendly [URL fragments🟉][10] (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different [URL🟉][11] fragments which can break links in a book (see [#27][12]). To avoid this vuepress needs to be configured to use the same slugger as glossarify-md.
+glossarify-md and vuepress both employ a [slug🟉][5] algorithm to create friendly [URL fragments🟉][6] (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different [URL🟉][7] fragments which can break links in a book (see [#27][8]). To avoid this vuepress needs to be configured to use the same slugger as glossarify-md.
 
-[glossarify-md⎆][1] uses \[github-slugger] internally. In case you want to get rid of glossarify-md you likely not want to have [slugs🟉][9] change again. Then you can use \[github-slugger] standalone with [vuepress⎆][2], like so:
+glossarify-md uses \[github-slugger] internally. In case you want to get rid of glossarify-md you likely not want to have [slugs🟉][5] change again. Then you can use \[github-slugger] standalone with vuepress, like so:
 
-*Using [github-slugger⎆][13] without [glossarify-md⎆][1]*
+*Using github-slugger without glossarify-md*
 
 ```js
 const GitHubSlugger = require("github-slugger");
@@ -143,28 +143,18 @@ module.exports = {
 };
 ```
 
-[1]: https://github.com/about-code/glossarify-md "This project."
+[1]: #appendix
 
-[2]: https://vuepress.vuejs.org "A static website generator translating markdown files into a website powered by [vuejs]."
+[2]: ../README.md
 
-[3]: #appendix
+[3]: https://vuepress.vuejs.org/guide/markdown.html
 
-[4]: ../README.md
+[4]: http://unifiedjs.com/explore/package/remark-frontmatter/
 
-[5]: https://vuepress.vuejs.org/guide/markdown.html
+[5]: ./glossary.md#slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
 
-[6]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
+[6]: ./glossary.md#url-fragment "The fragment is the part follwing the # in a URL."
 
-[7]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+[7]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
 
-[8]: http://unifiedjs.com/explore/package/remark-frontmatter/
-
-[9]: ./glossary.md#slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
-
-[10]: ./glossary.md#url-fragment "The fragment is the part follwing the # in a URL."
-
-[11]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
-
-[12]: https://github.com/about-code/glossarify-md/issues/27
-
-[13]: https://npmjs.com/package/github-slugger "A library providing support for slugs."
+[8]: https://github.com/about-code/glossarify-md/issues/27

--- a/doc/vuepress.md
+++ b/doc/vuepress.md
@@ -31,7 +31,7 @@ Below we assume a *sample* project structure like this:
 
 ## [Configure glossarify-md](#configure-glossarify-md)
 
-*[glossarify-md][1].conf.json*
+*[glossarify-md⎆][1].conf.json*
 
 ```json
 {
@@ -48,7 +48,7 @@ Below we assume a *sample* project structure like this:
 
 ## [Configure vuepress](#configure-vuepress)
 
-[glossarify-md][1] and [vuepress][2] need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix][3].
+[glossarify-md⎆][1] and [vuepress⎆][2] need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix][3].
 
 <em>./docs/.vuepress/config.js</em>
 
@@ -89,23 +89,23 @@ module.exports = {
 *   `npm start` builds and serves files quickly from `baseDir` with *live-reload*. This is what you probably want while writing even though it doesn't produce glossarified output.
 *   `npm run glossarify` writes glossarified markdown files to `outDir`
 *   `npm run glossarified` builds and serves the glossarified version from `outDir`.
-*   `npm run build` just builds the glossarified [vuepress][2] site without running a server.
+*   `npm run build` just builds the glossarified [vuepress⎆][2] site without running a server.
 
 More information see [README.md][4].
 
 ## [Markdown Extensions](#markdown-extensions)
 
-[Vuepress][2] supports some [Markdown Syntax][5] not covered by [CommonMark][6]. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with [glossarify-md][1] (see [Markdown Syntax Extensions][doc-syntax-extensions]).
+[Vuepress⎆][2] supports some [Markdown Syntax][5] not covered by [CommonMark⎆][6]. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with [glossarify-md⎆][1] (see [Markdown Syntax Extensions][doc-syntax-extensions]).
 
-| [Vuepress][2] Markdown Extension      | [remark][7] plug-in required with [glossarify-md][1] |
-| ------------------------------------- | ---------------------------------------------------- |
-| [Frontmatter][vp-frontmatter]         | [remark-frontmatter][8]                              |
-| [Custom Containers][vp-cc]            | None                                                 |
-| [GitHub Style Tables][vp-gh-tables]   | None                                                 |
-| [Table of Contents][vp-toc] `[[toc]]` | None                                                 |
-| [Emoji][vp-emoji]                     | None                                                 |
-| [Line Highlighting Codeblocks][vp-lh] | None                                                 |
-| [Import Code Snippets][vp-code]       | None                                                 |
+| [Vuepress⎆][2] Markdown Extension     | [remark⎆][7] plug-in required with [glossarify-md⎆][1] |
+| ------------------------------------- | ------------------------------------------------------ |
+| [Frontmatter][vp-frontmatter]         | [remark-frontmatter][8]                                |
+| [Custom Containers][vp-cc]            | None                                                   |
+| [GitHub Style Tables][vp-gh-tables]   | None                                                   |
+| [Table of Contents][vp-toc] `[[toc]]` | None                                                   |
+| [Emoji][vp-emoji]                     | None                                                   |
+| [Line Highlighting Codeblocks][vp-lh] | None                                                   |
+| [Import Code Snippets][vp-code]       | None                                                   |
 
 [vp-frontmatter]: https://vuepress.vuejs.org/guide/markdown.html#frontmatter
 
@@ -123,11 +123,11 @@ More information see [README.md][4].
 
 ## [Appendix](#appendix)
 
-[glossarify-md][1] and [vuepress][2] both employ a [slug🟉][9] algorithm to create friendly [URL fragments🟉][10] (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different [URL🟉][11] fragments which can break links in a book (see [#27][12]). To avoid this vuepress needs to be configured to use the same slugger as glossarify-md.
+[glossarify-md⎆][1] and [vuepress⎆][2] both employ a [slug🟉][9] algorithm to create friendly [URL fragments🟉][10] (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different [URL🟉][11] fragments which can break links in a book (see [#27][12]). To avoid this vuepress needs to be configured to use the same slugger as glossarify-md.
 
-[glossarify-md][1] uses \[github-slugger] internally. In case you want to get rid of glossarify-md you likely not want to have [slugs🟉][9] change again. Then you can use \[github-slugger] standalone with [vuepress][2], like so:
+[glossarify-md⎆][1] uses \[github-slugger] internally. In case you want to get rid of glossarify-md you likely not want to have [slugs🟉][9] change again. Then you can use \[github-slugger] standalone with [vuepress⎆][2], like so:
 
-*Using [github-slugger][13] without [glossarify-md][1]*
+*Using [github-slugger⎆][13] without [glossarify-md⎆][1]*
 
 ```js
 const GitHubSlugger = require("github-slugger");

--- a/doc/vuepress.md
+++ b/doc/vuepress.md
@@ -31,7 +31,7 @@ Below we assume a *sample* project structure like this:
 
 ## [Configure glossarify-md](#configure-glossarify-md)
 
-*glossarify-md.conf.json*
+*[glossarify-md…][1].conf.json*
 
 ```json
 {
@@ -48,7 +48,7 @@ Below we assume a *sample* project structure like this:
 
 ## [Configure vuepress](#configure-vuepress)
 
-glossarify-md and vuepress need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix][1].
+[glossarify-md…][1] and [vuepress…][2] need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix][3].
 
 <em>./docs/.vuepress/config.js</em>
 
@@ -89,23 +89,23 @@ module.exports = {
 *   `npm start` builds and serves files quickly from `baseDir` with *live-reload*. This is what you probably want while writing even though it doesn't produce glossarified output.
 *   `npm run glossarify` writes glossarified markdown files to `outDir`
 *   `npm run glossarified` builds and serves the glossarified version from `outDir`.
-*   `npm run build` just builds the glossarified vuepress site without running a server.
+*   `npm run build` just builds the glossarified [vuepress…][2] site without running a server.
 
-More information see [README.md][2].
+More information see [README.md][4].
 
 ## [Markdown Extensions](#markdown-extensions)
 
-Vuepress supports some [Markdown Syntax][3] not covered by CommonMark. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with glossarify-md (see [Markdown Syntax Extensions][doc-syntax-extensions]).
+[Vuepress…][2] supports some [Markdown Syntax][5] not covered by [CommonMark…][6]. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with [glossarify-md…][1] (see [Markdown Syntax Extensions][doc-syntax-extensions]).
 
-| Vuepress Markdown Extension           | remark plug-in required with glossarify-md |
-| ------------------------------------- | ------------------------------------------ |
-| [Frontmatter][vp-frontmatter]         | [remark-frontmatter][4]                    |
-| [Custom Containers][vp-cc]            | None                                       |
-| [GitHub Style Tables][vp-gh-tables]   | None                                       |
-| [Table of Contents][vp-toc] `[[toc]]` | None                                       |
-| [Emoji][vp-emoji]                     | None                                       |
-| [Line Highlighting Codeblocks][vp-lh] | None                                       |
-| [Import Code Snippets][vp-code]       | None                                       |
+| [Vuepress…][2] Markdown Extension     | [remark…][7] plug-in required with [glossarify-md…][1] |
+| ------------------------------------- | ------------------------------------------------------ |
+| [Frontmatter][vp-frontmatter]         | [remark-frontmatter][8]                                |
+| [Custom Containers][vp-cc]            | None                                                   |
+| [GitHub Style Tables][vp-gh-tables]   | None                                                   |
+| [Table of Contents][vp-toc] `[[toc]]` | None                                                   |
+| [Emoji][vp-emoji]                     | None                                                   |
+| [Line Highlighting Codeblocks][vp-lh] | None                                                   |
+| [Import Code Snippets][vp-code]       | None                                                   |
 
 [vp-frontmatter]: https://vuepress.vuejs.org/guide/markdown.html#frontmatter
 
@@ -123,11 +123,11 @@ Vuepress supports some [Markdown Syntax][3] not covered by CommonMark. While mos
 
 ## [Appendix](#appendix)
 
-glossarify-md and vuepress both employ a [slug🟉][5] algorithm to create friendly [URL fragments🟉][6] (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different [URL🟉][7] fragments which can break links in a book (see [#27][8]). To avoid this vuepress needs to be configured to use the same slugger as glossarify-md.
+[glossarify-md…][1] and [vuepress…][2] both employ a [slug🟉][9] algorithm to create friendly [URL fragments🟉][10] (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different [URL🟉][11] fragments which can break links in a book (see [#27][12]). To avoid this vuepress needs to be configured to use the same slugger as glossarify-md.
 
-glossarify-md uses \[github-slugger] internally. In case you want to get rid of glossarify-md you likely not want to have [slugs🟉][5] change again. Then you can use \[github-slugger] standalone with vuepress, like so:
+[glossarify-md…][1] uses \[github-slugger] internally. In case you want to get rid of glossarify-md you likely not want to have [slugs🟉][9] change again. Then you can use \[github-slugger] standalone with [vuepress…][2], like so:
 
-*Using github-slugger without glossarify-md*
+*Using [github-slugger…][13] without [glossarify-md…][1]*
 
 ```js
 const GitHubSlugger = require("github-slugger");
@@ -143,18 +143,28 @@ module.exports = {
 };
 ```
 
-[1]: #appendix
+[1]: https://github.com/about-code/glossarify-md "This project."
 
-[2]: ../README.md
+[2]: https://vuepress.vuejs.org "A static website generator translating markdown files into a website powered by [vuejs]."
 
-[3]: https://vuepress.vuejs.org/guide/markdown.html
+[3]: #appendix
 
-[4]: http://unifiedjs.com/explore/package/remark-frontmatter/
+[4]: ../README.md
 
-[5]: ./glossary.md#slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
+[5]: https://vuepress.vuejs.org/guide/markdown.html
 
-[6]: ./glossary.md#url-fragment "The fragment is the part follwing the # in a URL."
+[6]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
 
-[7]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+[7]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
 
-[8]: https://github.com/about-code/glossarify-md/issues/27
+[8]: http://unifiedjs.com/explore/package/remark-frontmatter/
+
+[9]: ./glossary.md#slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
+
+[10]: ./glossary.md#url-fragment "The fragment is the part follwing the # in a URL."
+
+[11]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+
+[12]: https://github.com/about-code/glossarify-md/issues/27
+
+[13]: https://npmjs.com/package/github-slugger "A library providing support for slugs."

--- a/doc/vuepress.md
+++ b/doc/vuepress.md
@@ -4,14 +4,6 @@ Below we assume a *sample* project structure like this:
 
 [doc-syntax-extensions]: ./markdown-syntax-extensions.md
 
-[CommonMark]: https://www.commonmark.org
-
-[github-slugger]: https://npmjs.com/package/github-slugger
-
-[glossarify-md]: https://github.com/about-code/glossarify-md
-
-[vuepress]: https://vuepress.vuejs.org
-
     ${root}
        +- docs/
        |   +- .vuepress/
@@ -39,7 +31,7 @@ Below we assume a *sample* project structure like this:
 
 ## [Configure glossarify-md](#configure-glossarify-md)
 
-*glossarify-md.conf.json*
+*[glossarify-md][1].conf.json*
 
 ```json
 {
@@ -56,7 +48,7 @@ Below we assume a *sample* project structure like this:
 
 ## [Configure vuepress](#configure-vuepress)
 
-[glossarify-md] and [vuepress] need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix][1].
+[glossarify-md][1] and [vuepress][2] need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix][3].
 
 <em>./docs/.vuepress/config.js</em>
 
@@ -75,7 +67,7 @@ module.exports = {
 };
 ```
 
-> ⚠ **Important:** Vuepress maps headings onto section anchors which become part of a URL fragment like `http://.../#foo-anchor`. By default vuepress creates anchors with lowercase ASCII characters, only. In contrast [github-slugger] will map unicode characters onto their lowercase unicode equivalent, which then affects you our your readers in the following way:
+> ⚠ **Important:** Vuepress maps headings onto section anchors which become part of a URL fragment like `http://.../#foo-anchor`. By default vuepress creates anchors with lowercase ASCII characters, only. In contrast github-slugger will map unicode characters onto their lowercase unicode equivalent, which then affects you our your readers in the following way:
 >
 > 1.  Readers who bookmarked a section URL with an ASCII-only `#`-URL fragment will still be able to open the web page they've bookmarked. But as a minor inconvenience their browser may no longer scroll to the bookmarked page section.
 >
@@ -97,23 +89,23 @@ module.exports = {
 *   `npm start` builds and serves files quickly from `baseDir` with *live-reload*. This is what you probably want while writing even though it doesn't produce glossarified output.
 *   `npm run glossarify` writes glossarified markdown files to `outDir`
 *   `npm run glossarified` builds and serves the glossarified version from `outDir`.
-*   `npm run build` just builds the glossarified [vuepress🟉][2] site without running a server.
+*   `npm run build` just builds the glossarified [vuepress][2] site without running a server.
 
-More information see [README.md][3].
+More information see [README.md][4].
 
 ## [Markdown Extensions](#markdown-extensions)
 
-[Vuepress🟉][2] supports some [Markdown Syntax][4] not covered by [CommonMark]. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with glossarify-md (see [Markdown Syntax Extensions][doc-syntax-extensions]).
+[Vuepress][2] supports some [Markdown Syntax][5] not covered by [CommonMark][6]. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with [glossarify-md][1] (see [Markdown Syntax Extensions][doc-syntax-extensions]).
 
-| [Vuepress🟉][2] Markdown Extension    | [remark🟉][5] plug-in required with glossarify-md |
-| ------------------------------------- | ------------------------------------------------- |
-| [Frontmatter][vp-frontmatter]         | [remark-frontmatter][6]                           |
-| [Custom Containers][vp-cc]            | None                                              |
-| [GitHub Style Tables][vp-gh-tables]   | None                                              |
-| [Table of Contents][vp-toc] `[[toc]]` | None                                              |
-| [Emoji][vp-emoji]                     | None                                              |
-| [Line Highlighting Codeblocks][vp-lh] | None                                              |
-| [Import Code Snippets][vp-code]       | None                                              |
+| [Vuepress][2] Markdown Extension      | [remark][7] plug-in required with [glossarify-md][1] |
+| ------------------------------------- | ---------------------------------------------------- |
+| [Frontmatter][vp-frontmatter]         | [remark-frontmatter][8]                              |
+| [Custom Containers][vp-cc]            | None                                                 |
+| [GitHub Style Tables][vp-gh-tables]   | None                                                 |
+| [Table of Contents][vp-toc] `[[toc]]` | None                                                 |
+| [Emoji][vp-emoji]                     | None                                                 |
+| [Line Highlighting Codeblocks][vp-lh] | None                                                 |
+| [Import Code Snippets][vp-code]       | None                                                 |
 
 [vp-frontmatter]: https://vuepress.vuejs.org/guide/markdown.html#frontmatter
 
@@ -131,11 +123,11 @@ More information see [README.md][3].
 
 ## [Appendix](#appendix)
 
-[glossarify-md] and [vuepress] both employ a [slug🟉][7] algorithm to create friendly [URL fragments🟉][8] (`#...`) for section links. When [vuepress🟉][2] is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different [URL🟉][9] fragments which can break links in a book (see [#27][10]). To avoid this vuepress needs to be configured to use the same slugger as [glossarify-md].
+[glossarify-md][1] and [vuepress][2] both employ a [slug🟉][9] algorithm to create friendly [URL fragments🟉][10] (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different [URL🟉][11] fragments which can break links in a book (see [#27][12]). To avoid this vuepress needs to be configured to use the same slugger as glossarify-md.
 
-[glossarify-md] uses [github-slugger] internally. In case you want to get rid of [glossarify-md] you likely not want to have [slugs🟉][7] change again. Then you can use [github-slugger] standalone with [vuepress🟉][2], like so:
+[glossarify-md][1] uses \[github-slugger] internally. In case you want to get rid of glossarify-md you likely not want to have [slugs🟉][9] change again. Then you can use \[github-slugger] standalone with [vuepress][2], like so:
 
-*Using github-slugger without glossarify-md*
+*Using [github-slugger][13] without [glossarify-md][1]*
 
 ```js
 const GitHubSlugger = require("github-slugger");
@@ -151,22 +143,28 @@ module.exports = {
 };
 ```
 
-[1]: #appendix
+[1]: https://github.com/about-code/glossarify-md "This project."
 
-[2]: ./glossary.md#vuepress "vuepress is a static website generator translating markdown files into a website powered by vuejs."
+[2]: https://vuepress.vuejs.org "A static website generator translating markdown files into a website powered by [vuejs]."
 
-[3]: ../README.md
+[3]: #appendix
 
-[4]: https://vuepress.vuejs.org/guide/markdown.html
+[4]: ../README.md
 
-[5]: ./glossary.md#remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
+[5]: https://vuepress.vuejs.org/guide/markdown.html
 
-[6]: http://unifiedjs.com/explore/package/remark-frontmatter/
+[6]: https://commonmark.org "Effort on providing a minimal set of standardized Markdown syntax."
 
-[7]: ./glossary.md#slug "A slug by our definition is a URL-friendly identifier created from arbitrary text that can be used within URL fragments to address headings / sections on a page."
+[7]: https://github.com/remarkjs/remark "remark is a parser and compiler project under the unified umbrella for Markdown text files in particular."
 
-[8]: ./glossary.md#url-fragment "The fragment is the part follwing the # in a URL."
+[8]: http://unifiedjs.com/explore/package/remark-frontmatter/
 
-[9]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+[9]: ./glossary.md#slug "A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page."
 
-[10]: https://github.com/about-code/glossarify-md/issues/27
+[10]: ./glossary.md#url-fragment "The fragment is the part follwing the # in a URL."
+
+[11]: ./glossary.md#uri--url "Uniform Resource Identifier and Uniform Resource Locator are both the same thing, which is an ID with a syntax scheme://authority.tld/path/#fragment?query like https://my.org/foo/#bar?q=123."
+
+[12]: https://github.com/about-code/glossarify-md/issues/27
+
+[13]: https://npmjs.com/package/github-slugger "A library providing support for slugs."

--- a/doc/vuepress.md
+++ b/doc/vuepress.md
@@ -31,7 +31,7 @@ Below we assume a *sample* project structure like this:
 
 ## [Configure glossarify-md](#configure-glossarify-md)
 
-*[glossarify-md…][1].conf.json*
+*[glossarify-md][1].conf.json*
 
 ```json
 {
@@ -48,7 +48,7 @@ Below we assume a *sample* project structure like this:
 
 ## [Configure vuepress](#configure-vuepress)
 
-[glossarify-md…][1] and [vuepress…][2] need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix][3].
+[glossarify-md][1] and [vuepress][2] need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix][3].
 
 <em>./docs/.vuepress/config.js</em>
 
@@ -89,23 +89,23 @@ module.exports = {
 *   `npm start` builds and serves files quickly from `baseDir` with *live-reload*. This is what you probably want while writing even though it doesn't produce glossarified output.
 *   `npm run glossarify` writes glossarified markdown files to `outDir`
 *   `npm run glossarified` builds and serves the glossarified version from `outDir`.
-*   `npm run build` just builds the glossarified [vuepress…][2] site without running a server.
+*   `npm run build` just builds the glossarified [vuepress][2] site without running a server.
 
 More information see [README.md][4].
 
 ## [Markdown Extensions](#markdown-extensions)
 
-[Vuepress…][2] supports some [Markdown Syntax][5] not covered by [CommonMark…][6]. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with [glossarify-md…][1] (see [Markdown Syntax Extensions][doc-syntax-extensions]).
+[Vuepress][2] supports some [Markdown Syntax][5] not covered by [CommonMark][6]. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with [glossarify-md][1] (see [Markdown Syntax Extensions][doc-syntax-extensions]).
 
-| [Vuepress…][2] Markdown Extension     | [remark…][7] plug-in required with [glossarify-md…][1] |
-| ------------------------------------- | ------------------------------------------------------ |
-| [Frontmatter][vp-frontmatter]         | [remark-frontmatter][8]                                |
-| [Custom Containers][vp-cc]            | None                                                   |
-| [GitHub Style Tables][vp-gh-tables]   | None                                                   |
-| [Table of Contents][vp-toc] `[[toc]]` | None                                                   |
-| [Emoji][vp-emoji]                     | None                                                   |
-| [Line Highlighting Codeblocks][vp-lh] | None                                                   |
-| [Import Code Snippets][vp-code]       | None                                                   |
+| [Vuepress][2] Markdown Extension      | [remark][7] plug-in required with [glossarify-md][1] |
+| ------------------------------------- | ---------------------------------------------------- |
+| [Frontmatter][vp-frontmatter]         | [remark-frontmatter][8]                              |
+| [Custom Containers][vp-cc]            | None                                                 |
+| [GitHub Style Tables][vp-gh-tables]   | None                                                 |
+| [Table of Contents][vp-toc] `[[toc]]` | None                                                 |
+| [Emoji][vp-emoji]                     | None                                                 |
+| [Line Highlighting Codeblocks][vp-lh] | None                                                 |
+| [Import Code Snippets][vp-code]       | None                                                 |
 
 [vp-frontmatter]: https://vuepress.vuejs.org/guide/markdown.html#frontmatter
 
@@ -123,11 +123,11 @@ More information see [README.md][4].
 
 ## [Appendix](#appendix)
 
-[glossarify-md…][1] and [vuepress…][2] both employ a [slug🟉][9] algorithm to create friendly [URL fragments🟉][10] (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different [URL🟉][11] fragments which can break links in a book (see [#27][12]). To avoid this vuepress needs to be configured to use the same slugger as glossarify-md.
+[glossarify-md][1] and [vuepress][2] both employ a [slug🟉][9] algorithm to create friendly [URL fragments🟉][10] (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different [URL🟉][11] fragments which can break links in a book (see [#27][12]). To avoid this vuepress needs to be configured to use the same slugger as glossarify-md.
 
-[glossarify-md…][1] uses \[github-slugger] internally. In case you want to get rid of glossarify-md you likely not want to have [slugs🟉][9] change again. Then you can use \[github-slugger] standalone with [vuepress…][2], like so:
+[glossarify-md][1] uses \[github-slugger] internally. In case you want to get rid of glossarify-md you likely not want to have [slugs🟉][9] change again. Then you can use \[github-slugger] standalone with [vuepress][2], like so:
 
-*Using [github-slugger…][13] without [glossarify-md…][1]*
+*Using [github-slugger][13] without [glossarify-md][1]*
 
 ```js
 const GitHubSlugger = require("github-slugger");

--- a/glossarify-md.conf.json
+++ b/glossarify-md.conf.json
@@ -6,6 +6,10 @@
     {
       "file": "./glossary.md",
       "termHint": "🟉"
+    },
+    {
+      "file": "./references.md",
+      "linkUris": true
     }
   ],
   "ignoreCase": true,

--- a/glossarify-md.conf.json
+++ b/glossarify-md.conf.json
@@ -9,7 +9,6 @@
     },
     {
       "file": "./_references.md",
-      "termHint": "…",
       "linkUris": true
     }
   ],

--- a/glossarify-md.conf.json
+++ b/glossarify-md.conf.json
@@ -8,7 +8,7 @@
       "termHint": "🟉"
     },
     {
-      "file": "./references.md",
+      "file": "./_references.md",
       "termHint": "…",
       "linkUris": true
     }

--- a/glossarify-md.conf.json
+++ b/glossarify-md.conf.json
@@ -14,7 +14,6 @@
   ],
   "ignoreCase": true,
   "linking": {
-    "baseUrl": "",
     "paths": "relative",
     "mentions": "first-in-paragraph",
     "headingDepths": [

--- a/glossarify-md.conf.json
+++ b/glossarify-md.conf.json
@@ -9,7 +9,7 @@
     },
     {
       "file": "./references.md",
-      "termHint": "⎆",
+      "termHint": "…",
       "linkUris": true
     }
   ],

--- a/glossarify-md.conf.json
+++ b/glossarify-md.conf.json
@@ -9,6 +9,7 @@
     },
     {
       "file": "./references.md",
+      "termHint": "⎆",
       "linkUris": true
     }
   ],

--- a/lib/ast/with/node-type.md
+++ b/lib/ast/with/node-type.md
@@ -1,24 +1,27 @@
 # Syntax Extensions and Custom Node Types
 
+[AST]: https://github.com/syntax-tree/unist "Abstract Syntax Tree"
+[Node]: https://github.com/syntax-tree/unist#node
+[mdAST]: https://github.com/syntax-tree/mdast
+[CMSM]: https://github.com/micromark/common-markup-state-machine#6-parsing
+[Construct]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L167
+[Okay]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L142
+[NotOkay]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L147
+[State]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L137
+[SyntaxExtension]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L210
+[Tokenize]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L165
+[micromark]: https://github.com/micromark/micromark
+[micromark-constructs]: https://github.com/micromark/micromark/blob/main/lib/constructs.mjs
+[micromark-syntax-extension]: https://github.com/micromark/micromark#syntaxextension
+[micromark-extension-footnote]: https://github.com/micromark/micromark-extension-footnote/blob/0.3.2/index.js#L35
+[mdast-util-from-markdown]: https://github.com/syntax-tree/mdast-util-from-markdown
+[mdast-util-to-markdown]: https://github.com/syntax-tree/mdast-util-to-markdown
+[mdast-util-to-markdown-handlers]: https://github.com/syntax-tree/mdast-util-to-markdown#optionshandlers
+[mdast-util-to-markdown-unsafe]: https://github.com/syntax-tree/mdast-util-to-markdown#optionsunsafe
+[unified]: https://github.com/unifiedjs/unified#processordatakey-value
+[glossarify-md]: https://github.com/about-code/glossarify-md
+
 > This is meant to be read by [glossarify-md] *developers* (not users)
-
-Custom node types need to adhere to a minimal interface:
-
-~~~js
-const SYMBOL = Symbol('myNode');
-class MyNode {
-    constructor() {
-      this.type = SYMBOL;
-    }
-}
-// ...if node.js support matrix permits it, use 'static' class fields
-MyNode.type = SYMBOL;
-MyNode.syntax = function() {}           // see micromark
-MyNode.fromMarkdown = function() {}     // see mdast-util-from-markdown
-MyNode.toMarkdown = function() {}       // see mdast-util-to-markdown
-~~~
-
-The interface reflects the overall process defined by [micromark] and implementation of those methods requires some deeper understanding of [micromark] and related projects:
 
 *Figure 1: Parsing, Manipulating, Serializing*
 ~~~
@@ -37,23 +40,49 @@ The interface reflects the overall process defined by [micromark] and implementa
 7. Output           | <~~~~ ['#','F','o','o','EOL'] <~~~~~~~~~~~~~~~~~~~~~~~~~~'
 ~~~
 
+*Figure 1* highlights the overall pipeline for processing Markdown with [micromark] and [mdast]. *glossarify-md* defines a `NodeType` interface which exposes methods for interfacing with the above pipeline using the extension points on the right of *Figure 1*:
+
+*Basic structure of a `NodeType`*
+~~~js
+const SYMBOL = 'my-node-type-name';  // choose a name likely to be unique
+class MyNode {
+    constructor() {
+      this.type = SYMBOL;
+    }
+}
+// ...if node.js support matrix permits it, use 'static' class fields
+MyNode.type = SYMBOL;
+MyNode.syntax = function() {}                  // see micromark
+MyNode.fromMarkdown = function() {}            // see mdast-util-from-markdown
+MyNode.toMarkdown = function() {}              // see mdast-util-to-markdown
+~~~
+
+In order to decide which methods need to be implemented it makes sense to distinguish between *Derived Node Types* and *Syntax Node Types*:
+
+1. If glossarify-md *derives* node types from processing of the input document's AST and inserts them into the AST, then there's no particular textual syntax for those derived nodes. Therefore neither `syntax()` nor `fromMarkdown` need to be implemented. However `toMarkdown()` needs to be implemented such that it prevents serializing a derived node by mapping it onto an empty string`""` (see the *TermOccurrence* node type, for an example of such a derived node type).
+
+   > Derived node types *must not* be serialized, because they would fail the roundtrip test. A roundtrip would require implementation of `syntax()` and `fromMarkdown()`.
+
+2. If glossarify-md should ever need to add support for non-standard Markdown Syntax, then all of these methods need to be implemented.
+
+   > **Note:** When spending this effort then - prior to implementing `NodeType` as described below -  consider contributing a *unified* or *remark plug-in*. It would make your syntax extension available to a much wider audience. Since glossarify-md can be extended with those plug-ins it can still be used with glossarify-md, later.
+
+For a complete reference on how to achieve 2. see the official docs on [Syntax Extensions (micromark)][micromark-syntax-extension] and related [micromark]'s related projects. Consider the next few sections to be only a rough overview and *notes* we took from studying [micromark] and mdast-util-* ourselves.
+
 ## `syntax()`
 
-If your node type is a type that is only to be inserted as part of modifying or extending an existing [AST] then there's nothing to implement here. Otherwise if the node type is to be created from parsing textual syntax in input documents then it must return an instance of a [micromark] [SyntaxExtension]:
+Returns:
 
+*Structure of micromark type [SyntaxExtension]*
 ~~~js
 {
-  // type: "SyntaxExtension"
   document: { ... }
   text: { ... }
   flow: { ... }
 }
 ~~~
 
-> *"A syntax extension is an object whose fields are the names of hooks,
-> referring to where constructs “hook” into."* Source: [micromark-syntax-extension]
-
-For a deeper understanding of the different hooks familiarize yourself with [micromark] and the Common Markup State Machine ([CMSM]). We'll focus on the pipeline principles, for now. A [SyntaxExtension] "hook" must be associated with mappings of character codes onto syntax [Construct]s:
+Crucial part of a [SyntaxExtension] is the `documents` property which holds mappings of *character codes* onto an object of micromark datatype [Construct]:
 
 *Example: SyntaxExtension*
 ~~~js
@@ -69,9 +98,7 @@ For a deeper understanding of the different hooks familiarize yourself with [mic
 }
 ~~~
 
-See also built-in [micromark-constructs]. A good example may also be [micromark-extension-footnote].
-
-The character code determines the first character participating in a syntax construct which when found causes the extension's `tokenize(effects, ok, nok)` function to be invoked.
+The character code determines the first character participating in a syntax construct which when found causes a [Construct]'s `tokenize(effects, ok, nok)` function to be invoked. [Tokenize] functions participate in a *Common Markup State Machine* ([CMSM]):
 
 *Example: Tokenizer in [micromark-extension-footnote]:*
 ~~~js
@@ -100,9 +127,7 @@ function tokenizeDefinitionStart(effects, ok, nok) {
 }
 ~~~
 
-[Tokenize] functions...
-
-- ...return a [State] function representing the *initial state* of the syntax state machine (*state-as-a-function* pattern). State functions need access to `effects, ok, nok` so may be realised as inner functions.
+[Tokenize] functions return a *[State] function* representing the *initial state* of the syntax state machine (*state-as-a-function* pattern). State functions need access to `effects, ok, nok` so are typically implemented as inner functions of a Tokenize function.
 
 [State] functions...
 
@@ -121,7 +146,7 @@ Given the character is an expected one, then a State function...
 1. ...consumes the *current character* using `effects.consume(code)`
 1. ...at some point enqueues an *End Token* using  `effects.exit()`
 
-So in the example above we see all this realized as...
+To sum up, in the example above we see all this realized as...
 
 - a [Tokenize] function `tokenizeDefinitionStart()` which returns a `start()` [State] function
 - how `start()`
@@ -134,21 +159,25 @@ So in the example above we see all this realized as...
   1. and once again makes sure the character is one it expects
   1. and eventually returns yet another [State] function and so on...
 
-What we can not directly see from the example, but guess, is that those tokens entered but not yet exited [will be exited at some point][micromark-extension-footnote] using `effects.exit(...)` and that eventually when processing the syntax construct is done `ok(code)` will be invoked.
+What we can not see right from the example, but guess, is the fact that those tokens which entered but have not yet exited *[will be exited "at some point"][micromark-extension-footnote]* using `effects.exit(...)`.
+
+Further Reading:
+
+- [micromark-extension-footnote] - Example of a non-standard syntax extension
+- [micromark-constructs] - Examples of CommonMark syntax constructs supported natively by micromark
 
 ## `fromMarkdown()`
 
-> If your node type is a node that is only to be inserted as part of modifying or extending an existing [AST], then there's nothing to implement! (Remind Figure 1 above).
+> Remind initial notes below Figure 1 for when to implementthis.
 
-We have written our custom syntax tokens onto the token queue by implementing `syntax()`. If we want the tokens and data to make it into an [AST] we need some place which creates AST-[Node]s from the tokens. This is what an implementation of `fromMarkdown()` is concerned with. In particular it creates an [mdAST], that is, an [AST] *for Markdown*. For now we refer to [mdast-util-from-markdown] for any further examples.
-
+With `syntax()` we have written custom syntax tokens onto the token stream/queue. If we want the tokens and data to make it into an [AST] we need some place which creates AST-[Node]s from these tokens. This is what `fromMarkdown()` is concerned with. In particular it creates an [mdAST] node or sub-tree which is to be inserted into the markdown documents [mdAST]. For now we refer to [mdast-util-from-markdown] for any further examples.
 
 ## `toMarkdown()`
 
 This method returns an [mdast-util-to-markdown] options object. The method must be implemented for any node type in the [AST]. It must even be implemented for nodes that might not have any serialized representation. However, in the latter case an implementation is pretty simple:
 
 ~~~js
-const SYMBOL = Symbol("myNode");
+const SYMBOL = "my-node-type-name";
 class MyNode {
     static toMarkdown() {
         return {
@@ -158,13 +187,11 @@ class MyNode {
 }
 ~~~
 
-Otherwise your [`handler`][mdast-util-to-markdown-handlers] were concerned with taking `node` which might be a subtree and serialize it into a string representation. Also have a look at the [`unsafe`][mdast-util-to-markdown-unsafe] option to register various characters that might be *unsafe* to use in the
-context of your syntax construct.
+Otherwise your [`handlers`][mdast-util-to-markdown-handlers] are concerned with taking `node` which might be a subtree and serialize it into a string representation. Also have a look at the [`unsafe`][mdast-util-to-markdown-unsafe] option to register various characters that need escaping in the context of your syntax construct.
 
 ## Register Custom Node Type
 
-Eventually we need to register our custom node type with the pipeline shown in
-Figure 1. We've written a utility function `withNodeType()` to handle that:
+Eventually we need to register our custom node type with glossarify-md's *unified-engine* processor shown. We've written a utility function `withNodeType()` to handle that:
 
 *lib/reader.js*
 ~~~js
@@ -186,24 +213,3 @@ Internally `withNodeType` calls our Node Type's `syntax()`, `fromMarkdown()` and
 - `toMarkdownExtensions: [...]`
 
 in the [unified.processor][unified] context.
-
-[AST]: https://github.com/syntax-tree/unist "Abstract Syntax Tree"
-[Node]: https://github.com/syntax-tree/unist#node
-[mdAST]: https://github.com/syntax-tree/mdast
-[CMSM]: https://github.com/micromark/common-markup-state-machine#6-parsing
-[Construct]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L167
-[Okay]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L142
-[NotOkay]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L147
-[State]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L137
-[SyntaxExtension]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L210
-[Tokenize]: https://github.com/micromark/micromark/blob/2.11.1/lib/shared-types.d.ts#L165
-[micromark]: https://github.com/micromark/micromark
-[micromark-constructs]: https://github.com/micromark/micromark/blob/main/lib/constructs.mjs
-[micromark-syntax-extension]: https://github.com/micromark/micromark#syntaxextension
-[micromark-extension-footnote]: https://github.com/micromark/micromark-extension-footnote/blob/0.3.2/index.js#L35
-[mdast-util-from-markdown]: https://github.com/syntax-tree/mdast-util-from-markdown
-[mdast-util-to-markdown]: https://github.com/syntax-tree/mdast-util-to-markdown
-[mdast-util-to-markdown-handlers]: https://github.com/syntax-tree/mdast-util-to-markdown#optionshandlers
-[mdast-util-to-markdown-unsafe]: https://github.com/syntax-tree/mdast-util-to-markdown#optionsunsafe
-[unified]: https://github.com/unifiedjs/unified#processordatakey-value
-[glossarify-md]: https://github.com/about-code/glossarify-md

--- a/md/CONTRIBUTING.md
+++ b/md/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
-
+[VSCode]: https://code.visualstudio.com
 [launch configuration]: ./.vscode/launch.json
 
 ## Table of Contents
@@ -15,7 +15,7 @@
 *Prerequisites*
 - [`git`](https://git-scm.com)
 - [`node` and `npm`](https://nodejs.org) - we aim to support the last two Node LTS releases ([Maintenance, Active](https://nodejs.org/en/about/releases/)) as well as the latest Non-LTS versions ([Current](https://nodejs.org/en/about/releases/))
-- Editor of your choice, e.g. Atom, VSCode, etc.
+- Editor of your choice, e.g. [Atom](https://atom.io), [VSCode](https://code.visualstudio.com), etc.
 
 > **⚠ Important (Windows-Users):** Configure your editor or IDE to use Unix-style line-endings (LF) for this project. Unix-Style-Endings are required at least for *Markdown*, *JS* and *JSON* files.
 
@@ -69,7 +69,7 @@ npm run experiment
 
 ## Debugging
 
-The project includes a VSCode `Debug Experiment` [launch configuration] for debugging [experiments](#experiments) with the internal debugger (`F5` key).
+The project includes a [VSCode] `Debug Experiment` [launch configuration] for debugging [experiments](#experiments) with the internal debugger (`F5` key).
 
 Alternatively
 

--- a/md/CONTRIBUTING.md
+++ b/md/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
-[VSCode]: https://code.visualstudio.com
+
 [launch configuration]: ./.vscode/launch.json
 
 ## Table of Contents
@@ -15,7 +15,7 @@
 *Prerequisites*
 - [`git`](https://git-scm.com)
 - [`node` and `npm`](https://nodejs.org) - we aim to support the last two Node LTS releases ([Maintenance, Active](https://nodejs.org/en/about/releases/)) as well as the latest Non-LTS versions ([Current](https://nodejs.org/en/about/releases/))
-- Editor of your choice, e.g. [Atom](https://atom.io), [VSCode](https://code.visualstudio.com), etc.
+- Editor of your choice, e.g. Atom, VSCode, etc.
 
 > **⚠ Important (Windows-Users):** Configure your editor or IDE to use Unix-style line-endings (LF) for this project. Unix-Style-Endings are required at least for *Markdown*, *JS* and *JSON* files.
 
@@ -69,7 +69,7 @@ npm run experiment
 
 ## Debugging
 
-The project includes a [VSCode] `Debug Experiment` [launch configuration] for debugging [experiments](#experiments) with the internal debugger (`F5` key).
+The project includes a VSCode `Debug Experiment` [launch configuration] for debugging [experiments](#experiments) with the internal debugger (`F5` key).
 
 Alternatively
 

--- a/md/README.md
+++ b/md/README.md
@@ -322,7 +322,7 @@ Sometimes you might whish to have multiple glossaries. For example as a Requirem
 
 By adding *requirements.md* to the list of glossaries every use of *REQ-1* or *REQ-2* in documents gets linked to the requirements glossary. To navigate the opposite direction from a requirement to sections where those got mentioned you can generate a [Book Index](#book-index).
 
-## Sorting your glossaries
+## Sorting Glossaries
 
 Add `sort` with `"asc"` (ascending) or `"desc"` (descending) to glossaries you want glossarify-md sort for you:
 
@@ -948,7 +948,7 @@ The relation to [`linking.headingDepths`](#linkingheadingdepths) is that *this* 
 }`
 ~~~
 
-Locale options to control [sorting](#sorting-your-glossaries). See [`Intl.Collator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/Collator).
+Locale options to control [sorting](#sorting-glossaries). See [`Intl.Collator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator/Collator).
 
 #### `keepRawFiles`
 

--- a/md/README.md
+++ b/md/README.md
@@ -4,35 +4,24 @@
 ![Nightly Tests (Latest Dependencies)](https://github.com/about-code/glossarify-md/workflows/Tests%20(with%20latest%20deps)/badge.svg)
 
 
-[glossarify-md] is a command line tool to help Markdown writers with
+glossarify-md is a command line tool to help Markdown writers with
 
 - **Cross-Linking** (primary use case): autolink terms to some definition in a glossary
 - **Indexes**: generate indexes from glossary terms and navigate to where they were mentioned
 - **Lists**: generate arbitrary lists such as *List of Tables*, *List of Figures*, *List of Listings*, *List of Definitions*, *List of Formulas*, and so forth...
 
-[vuepress] users might be interested in learning [how to use the tool with vuepress][doc-vuepress].
+vuepress users might be interested in learning [how to use the tool with vuepress][doc-vuepress].
 
 [doc-vocabulary-uris]: https://github.com/about-code/glossarify-md/blob/master/doc/vocabulary-uris.md
 [doc-skos-interop]: https://github.com/about-code/glossarify-md/blob/master/doc/skos-interop.md
 [doc-vuepress]: https://github.com/about-code/glossarify-md/blob/master/doc/vuepress.md
 [doc-syntax-extensions]: https://github.com/about-code/glossarify-md/blob/master/doc/markdown-syntax-extensions.md
 [doc-conceptual-layers]: https://github.com/about-code/glossarify-md/blob/master/doc/conceptual-layers.md
-[CommonMark]: https://www.commonmark.org
-[GFM]: https://github.github.com/gfm/
-[glob]: https://github.com/isaacs/node-glob#glob-primer
-[glossarify-md]: https://github.com/about-code/glossarify-md
-[jsonld]: https://npmjs.com/package/jsonld
 [link reference definitions]: https://spec.commonmark.org/0.30/#link-reference-definition
-[mdast]: https://github.com/syntax-tree/mdast
-[micromark]: https://github.com/micromark/
-[pandoc]: https://pandoc.org
 [pandoc-heading-ids]: https://pandoc.org/MANUAL.html#heading-identifiers
-[remark]: https://github.com/remarkjs/remark
 [remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
-[unified]: https://unifiedjs.com
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
-[vuepress]: https://vuepress.vuejs.org
 
 ## Table of Contents
 
@@ -191,7 +180,7 @@ This is a text which uses a glossary Term to describe something.
 ```
 
 
-Then run [glossarify-md] with a [glossarify-md.conf.json](#configuration):
+Then run glossarify-md with a [glossarify-md.conf.json](#configuration):
 
 ~~~
 npx glossarify-md --config ./glossarify-md.conf.json
@@ -303,7 +292,7 @@ In the output files aliases will be linked to their related term:
 
 Glossaries can be associated with *term hints*. Term hints may be used to indicate that a link refers to a glossary term and in case of [multiple glossaries][multiple-glossaries] to which one. Use `"${term}"` to control placement of a `termHint`. For example, `"☛ ${term}"` puts the symbol `☛` in front of a linkified term occurrence.
 
-> **ⓘ Since v5.0.0**: `file` can also be used with a [glob] pattern. More see [Cross-Linking].
+> **ⓘ Since v5.0.0**: `file` can also be used with a glob pattern. More see [Cross-Linking].
 
 ## Multiple Glossaries
 
@@ -335,7 +324,7 @@ By adding *requirements.md* to the list of glossaries every use of *REQ-1* or *R
 
 ## Sorting your glossaries
 
-Add `sort` with `"asc"` (ascending) or `"desc"` (descending) to glossaries you want [glossarify-md] sort for you:
+Add `sort` with `"asc"` (ascending) or `"desc"` (descending) to glossaries you want glossarify-md sort for you:
 
 *glossarify-md.conf.json*
 ```json
@@ -366,7 +355,7 @@ The i18n-object is passed *as is* to the collator function. Thus you can use add
 
 *Term-based auto-linking* is what we've seen so far. It is to assume headings in markdown files called *glossaries* are *terms* that whenever being mentioned in text are being turned into a link to the glossary section where they have been defined as a term.
 
-**Since v5.0.0** we've added a few features which let us evolve that principle into a more generic means of cross-linking beginning with support for [glob] patterns in `glossaries.file`. For example with ...
+**Since v5.0.0** we've added a few features which let us evolve that principle into a more generic means of cross-linking beginning with support for glob patterns in `glossaries.file`. For example with ...
 
 ```json
 "glossaries": [
@@ -388,7 +377,7 @@ If the same section heading exists more than once then you might want to link to
 
 **Since v5.0.0** we've added support for manual cross-linking through [pandoc's concept of heading ids][pandoc-heading-ids]. These allow you to assign identifiers which are more stable for referencing than auto-generated IDs derived from the heading phrase (slugs).
 
-> **ⓘ Note:** Pandoc's identifier syntax is not standardized in [CommonMark].
+> **ⓘ Note:** Pandoc's identifier syntax is not standardized in CommonMark.
 
 [Sample]: document `./pages/page1.md` declares a heading
 
@@ -403,7 +392,7 @@ with heading-id `#s-241`. **Given that `#s-241` is *unique* across all documents
 [any phrase](#s-241)
 ~~~
 
-In any file being processed [glossarify-md] will resolve the actual path to the definition:
+In any file being processed glossarify-md will resolve the actual path to the definition:
 
 */README.md*
 ~~~
@@ -456,7 +445,7 @@ Let's assume you have multiple glossaries and you want to create separate book i
 }
 ```
 
-> **ⓘ Note:** If you plan on translating markdown to HTML, e.g. with [vuepress](https://vuepress.vuejs.org), be aware that a file `index.md` will translate to `index.html` which is typically reserved for the default HTML file served under a domain. We recommend you choosing another name.
+> **ⓘ Note:** If you plan on translating markdown to HTML, e.g. with vuepress(https://vuepress.vuejs.org), be aware that a file `index.md` will translate to `index.html` which is typically reserved for the default HTML file served under a domain. We recommend you choosing another name.
 
 ### Lists
 
@@ -535,13 +524,13 @@ The link label for list items will be inferred in this order (first-match):
 ### List of Figures
 
 So far we used [`listOf`](#lists) to generate a list from *HTML elements* in Markdown. Writing HTML can be annoying, particularly if there is handier Markdown syntax for the elements to be listed. This is where
-`listOfFigures` and [`listOfTables`](#list-of-tables) fit in. It is a shortcut which makes [glossarify-md] generate the HTML anchor itself from Markdown's image syntax:
+`listOfFigures` and [`listOfTables`](#list-of-tables) fit in. It is a shortcut which makes glossarify-md generate the HTML anchor itself from Markdown's image syntax:
 
 ```md
 ![List item Label](./figure.png)
 ```
 
-Then you may only need to use HTML for dynamically rendered figures, e.g. a [PlantUML](https://plantuml.com) diagram:
+Then you may only need to use HTML for dynamically rendered figures, e.g. a PlantUML diagram:
 
 ````md
 <figure id="figure-gen">Dynamically Rendered Diagram</figure>
@@ -553,7 +542,7 @@ Then you may only need to use HTML for dynamically rendered figures, e.g. a [Pla
 ```
 ````
 
-To compile both figures into the same list one way to configure [glossarify-md] is to declare a `listOf` class *figure* (for HTML elements) and tell `listOfFigures` (for `![]()` images) to use the same classifier *figure*:
+To compile both figures into the same list one way to configure glossarify-md is to declare a `listOf` class *figure* (for HTML elements) and tell `listOfFigures` (for `![]()` images) to use the same classifier *figure*:
 
 *glossarify-md.conf.json* (since v5.0.0)
 
@@ -598,7 +587,7 @@ This configuration which would allow you to also choose a shorter classifier lik
 }
 ```
 
-In contrast to images Markdown tables have no notion of a table caption. To render a list item for a table [glossarify-md] tries to infer a list item label.
+In contrast to images Markdown tables have no notion of a table caption. To render a list item for a table glossarify-md tries to infer a list item label.
 
 One such inference looks at the **paragraph preceding the table**. If it **ends with an *emphasized* phrase** and the phrase itself is **terminated by a colon** then the tool uses that phrase as the item label:
 
@@ -650,7 +639,7 @@ The result for the tables above will be:
 > - [Average Prices by Article Category](#avg-prices)
 
 
-**Since v5.0.0** and the introduction of `listOf` all the previous examples will make [glossarify-md] annotate the table with an HTML anchor. So while not recommended due to verbosity, you could of course also just add an HTML anchor yourself, like described in [`listOf`](#lists):
+**Since v5.0.0** and the introduction of `listOf` all the previous examples will make glossarify-md annotate the table with an HTML anchor. So while not recommended due to verbosity, you could of course also just add an HTML anchor yourself, like described in [`listOf`](#lists):
 
 ```md
 <a id="avg-prices" class="table" title="Average Prices by Article Category"></a>
@@ -662,7 +651,7 @@ The result for the tables above will be:
 | 3        | Book        | $23.45     |
 ```
 
-> **ⓘ Note:** If [glossarify-md] can't find a list item label by any of the above means it will fall back to rendering a list item
+> **ⓘ Note:** If glossarify-md can't find a list item label by any of the above means it will fall back to rendering a list item
 > 1. using the table headers separated by comma,
 > 1. or if no headers, using the closest section heading
 > 1. or if no section heading, using the file name.
@@ -709,15 +698,15 @@ If the regular expression (RegExp) matches text in a paragraph, then *the paragr
 
 > **ⓘ When to consider "markdown syntax" in the RegExp**:
 >
-> You may noticed that the RegExp above doesn't assume *Task:* to be written between "bold" star markers `**`. The expression won't be matched against the input *you* wrote but against *plain text* cleaned from symbols contributing to [CommonMark] or [GFM] syntax.
+> You may noticed that the RegExp above doesn't assume *Task:* to be written between "bold" star markers `**`. The expression won't be matched against the input *you* wrote but against *plain text* cleaned from symbols contributing to CommonMark or GFM syntax.
 >
 > In case you use another Markdown flavor see our addendum on [Markdown Syntax Extensions][doc-syntax-extensions]. Without a proper plug-in its syntactical elements are likely considered plain text, too. Then they need to be taken care of in the RegExp to make it match.
 
 ## Structured Export and Import
 [doc-export-import]: #structured-export-and-import
-[SKOS]: https://w3.org/skos
+SKOS: https://w3.org/skos
 
-**Since v6.0.0** glossary terms can be exported to a structured JSON format (file extension `.json`). When [jsonld] is installed alongside glossarify-md then terms can also be exported to RDF N-Quads (file extension `.nq`).
+**Since v6.0.0** glossary terms can be exported to a structured JSON format (file extension `.json`). When jsonld is installed alongside glossarify-md then terms can also be exported to RDF N-Quads (file extension `.nq`).
 
 *glossarify-md.conf.json* (generates ./glossary.json)
 ~~~json
@@ -732,7 +721,7 @@ If the regular expression (RegExp) matches text in a paragraph, then *the paragr
 }
 ~~~
 
-Declare a glossary `uri` when exporting. It will make [glossarify-md] assign each term a *uniform resource identifier* by combining the glossary's `uri` with a term's book-internal identifier (see [`headingIdAlgorithm`][headingIdAlgorithm]). Note that URIs are not required to resolve to some web page but *can* do so. More on the idea behind URIs read [here][doc-vocabulary-uris]. You can import terms the same way using `import` instead.
+Declare a glossary `uri` when exporting. It will make glossarify-md assign each term a *uniform resource identifier* by combining the glossary's `uri` with a term's book-internal identifier (see [`headingIdAlgorithm`][headingIdAlgorithm]). Note that URIs are not required to resolve to some web page but *can* do so. More on the idea behind URIs read [here][doc-vocabulary-uris]. You can import terms the same way using `import` instead.
 
 *glossarify-md.conf.json* (generates ./glossary.md):
 ~~~json
@@ -747,7 +736,7 @@ Declare a glossary `uri` when exporting. It will make [glossarify-md] assign eac
 }
 ~~~
 
-> ⚠ **Important:** [glossarify-md] is able to import JSON glossaries from a remote location using `https`. While it will try to remove any Markdown and HTML from imported term definitions using [strip-markdown](https://npmjs.com/package/strip-markdown) it can only do so after `JSON.parse()`. As a rule of thumb never import from untrusted sources and assume that any files from a remote location could enable a remote entity to embed malicious code into outputs or execute such code in the runtime context of [glossarify-md]. Consider importing files statically after review.
+> ⚠ **Important:** glossarify-md is able to import JSON glossaries from a remote location using `https`. While it will try to remove any Markdown and HTML from imported term definitions using [strip-markdown](https://npmjs.com/package/strip-markdown) it can only do so after `JSON.parse()`. As a rule of thumb never import from untrusted sources and assume that any files from a remote location could enable a remote entity to embed malicious code into outputs or execute such code in the runtime context of glossarify-md. Consider importing files statically after review.
 
 Advanced topics on importing and exporting can be found [here](https://github.com/about-code/glossarify-md/blob/master/doc/skos-interop.md).
 
@@ -758,7 +747,7 @@ The term *support* refers to *runs on the given platform* and is subject to the 
 
 | NodeJS  | glossarify-md |                                                                           Current Test Matrix                                                                            |
 | ------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Current | v6+           | Tested. Should node.js introduce breaking changes which affect [glossarify-md], then we may choose to step back from supporting *Current* until it becomes the next LTS. |
+| Current | v6+           | Tested. Should node.js introduce breaking changes which affect glossarify-md, then we may choose to step back from supporting *Current* until it becomes the next LTS. |
 | 16 LTS  | v5, v6+       | Tested + Supported                                                                                                                                                       |
 | 14 LTS  | v4, v5, v6+   | Tested + Supported                                                                                                                                                       |
 | 12 LTS  | v3, v4, v5    |                                                                                                                                                                          |
@@ -1008,7 +997,7 @@ Whether to convert inline-links to [link reference definitions] (size-efficient)
 - **Default:** `true`
 - **Since:** v6.0.0
 
-Whether to linkify headings. Note that some Markdown-to-HTML renderers need headings to be linkified in order to be rendered URL-addressable and navigable. Others like [pandoc] don't need linkified headings but special syntax.
+Whether to linkify headings. Note that some Markdown-to-HTML renderers need headings to be linkified in order to be rendered URL-addressable and navigable. Others like pandoc don't need linkified headings but special syntax.
 
 See also:
 
@@ -1053,9 +1042,9 @@ where `baseUrl` will be used only if there's no glossary uri. The `*-7` hashsum 
 - **Default:** false
 - **Since:** v6.0.0
 
-Since v5 there has been support for *parsing* pandoc-style heading IDs from input markdown. In v6 we added support for *writing*  pandoc-style `{#id}` identifiers to output markdown to facilitate postprocessing with [pandoc].
+Since v5 there has been support for *parsing* pandoc-style heading IDs from input markdown. In v6 we added support for *writing*  pandoc-style `{#id}` identifiers to output markdown to facilitate postprocessing with pandoc.
 
-> **ⓘ Note:** Pandoc's identifier syntax is not standardized in [CommonMark].
+> **ⓘ Note:** Pandoc's identifier syntax is not standardized in CommonMark.
 
 See also
 

--- a/md/README.md
+++ b/md/README.md
@@ -4,24 +4,35 @@
 ![Nightly Tests (Latest Dependencies)](https://github.com/about-code/glossarify-md/workflows/Tests%20(with%20latest%20deps)/badge.svg)
 
 
-glossarify-md is a command line tool to help Markdown writers with
+[glossarify-md] is a command line tool to help Markdown writers with
 
 - **Cross-Linking** (primary use case): autolink terms to some definition in a glossary
 - **Indexes**: generate indexes from glossary terms and navigate to where they were mentioned
 - **Lists**: generate arbitrary lists such as *List of Tables*, *List of Figures*, *List of Listings*, *List of Definitions*, *List of Formulas*, and so forth...
 
-vuepress users might be interested in learning [how to use the tool with vuepress][doc-vuepress].
+[vuepress] users might be interested in learning [how to use the tool with vuepress][doc-vuepress].
 
 [doc-vocabulary-uris]: https://github.com/about-code/glossarify-md/blob/master/doc/vocabulary-uris.md
 [doc-skos-interop]: https://github.com/about-code/glossarify-md/blob/master/doc/skos-interop.md
 [doc-vuepress]: https://github.com/about-code/glossarify-md/blob/master/doc/vuepress.md
 [doc-syntax-extensions]: https://github.com/about-code/glossarify-md/blob/master/doc/markdown-syntax-extensions.md
 [doc-conceptual-layers]: https://github.com/about-code/glossarify-md/blob/master/doc/conceptual-layers.md
+[CommonMark]: https://www.commonmark.org
+[GFM]: https://github.github.com/gfm/
+[glob]: https://github.com/isaacs/node-glob#glob-primer
+[glossarify-md]: https://github.com/about-code/glossarify-md
+[jsonld]: https://npmjs.com/package/jsonld
 [link reference definitions]: https://spec.commonmark.org/0.30/#link-reference-definition
+[mdast]: https://github.com/syntax-tree/mdast
+[micromark]: https://github.com/micromark/
+[pandoc]: https://pandoc.org
 [pandoc-heading-ids]: https://pandoc.org/MANUAL.html#heading-identifiers
+[remark]: https://github.com/remarkjs/remark
 [remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
+[unified]: https://unifiedjs.com
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
+[vuepress]: https://vuepress.vuejs.org
 
 ## Table of Contents
 
@@ -180,7 +191,7 @@ This is a text which uses a glossary Term to describe something.
 ```
 
 
-Then run glossarify-md with a [glossarify-md.conf.json](#configuration):
+Then run [glossarify-md] with a [glossarify-md.conf.json](#configuration):
 
 ~~~
 npx glossarify-md --config ./glossarify-md.conf.json
@@ -292,7 +303,7 @@ In the output files aliases will be linked to their related term:
 
 Glossaries can be associated with *term hints*. Term hints may be used to indicate that a link refers to a glossary term and in case of [multiple glossaries][multiple-glossaries] to which one. Use `"${term}"` to control placement of a `termHint`. For example, `"☛ ${term}"` puts the symbol `☛` in front of a linkified term occurrence.
 
-> **ⓘ Since v5.0.0**: `file` can also be used with a glob pattern. More see [Cross-Linking].
+> **ⓘ Since v5.0.0**: `file` can also be used with a [glob] pattern. More see [Cross-Linking].
 
 ## Multiple Glossaries
 
@@ -324,7 +335,7 @@ By adding *requirements.md* to the list of glossaries every use of *REQ-1* or *R
 
 ## Sorting Glossaries
 
-Add `sort` with `"asc"` (ascending) or `"desc"` (descending) to glossaries you want glossarify-md sort for you:
+Add `sort` with `"asc"` (ascending) or `"desc"` (descending) to glossaries you want [glossarify-md] sort for you:
 
 *glossarify-md.conf.json*
 ```json
@@ -355,7 +366,7 @@ The i18n-object is passed *as is* to the collator function. Thus you can use add
 
 *Term-based auto-linking* is what we've seen so far. It is to assume headings in markdown files called *glossaries* are *terms* that whenever being mentioned in text are being turned into a link to the glossary section where they have been defined as a term.
 
-**Since v5.0.0** we've added a few features which let us evolve that principle into a more generic means of cross-linking beginning with support for glob patterns in `glossaries.file`. For example with ...
+**Since v5.0.0** we've added a few features which let us evolve that principle into a more generic means of cross-linking beginning with support for [glob] patterns in `glossaries.file`. For example with ...
 
 ```json
 "glossaries": [
@@ -377,7 +388,7 @@ If the same section heading exists more than once then you might want to link to
 
 **Since v5.0.0** we've added support for manual cross-linking through [pandoc's concept of heading ids][pandoc-heading-ids]. These allow you to assign identifiers which are more stable for referencing than auto-generated IDs derived from the heading phrase (slugs).
 
-> **ⓘ Note:** Pandoc's identifier syntax is not standardized in CommonMark.
+> **ⓘ Note:** Pandoc's identifier syntax is not standardized in [CommonMark].
 
 [Sample]: document `./pages/page1.md` declares a heading
 
@@ -392,7 +403,7 @@ with heading-id `#s-241`. **Given that `#s-241` is *unique* across all documents
 [any phrase](#s-241)
 ~~~
 
-In any file being processed glossarify-md will resolve the actual path to the definition:
+In any file being processed [glossarify-md] will resolve the actual path to the definition:
 
 */README.md*
 ~~~
@@ -445,7 +456,7 @@ Let's assume you have multiple glossaries and you want to create separate book i
 }
 ```
 
-> **ⓘ Note:** If you plan on translating markdown to HTML, e.g. with vuepress(https://vuepress.vuejs.org), be aware that a file `index.md` will translate to `index.html` which is typically reserved for the default HTML file served under a domain. We recommend you choosing another name.
+> **ⓘ Note:** If you plan on translating markdown to HTML, e.g. with [vuepress](https://vuepress.vuejs.org), be aware that a file `index.md` will translate to `index.html` which is typically reserved for the default HTML file served under a domain. We recommend you choosing another name.
 
 ### Lists
 
@@ -524,13 +535,13 @@ The link label for list items will be inferred in this order (first-match):
 ### List of Figures
 
 So far we used [`listOf`](#lists) to generate a list from *HTML elements* in Markdown. Writing HTML can be annoying, particularly if there is handier Markdown syntax for the elements to be listed. This is where
-`listOfFigures` and [`listOfTables`](#list-of-tables) fit in. It is a shortcut which makes glossarify-md generate the HTML anchor itself from Markdown's image syntax:
+`listOfFigures` and [`listOfTables`](#list-of-tables) fit in. It is a shortcut which makes [glossarify-md] generate the HTML anchor itself from Markdown's image syntax:
 
 ```md
 ![List item Label](./figure.png)
 ```
 
-Then you may only need to use HTML for dynamically rendered figures, e.g. a PlantUML diagram:
+Then you may only need to use HTML for dynamically rendered figures, e.g. a [PlantUML](https://plantuml.com) diagram:
 
 ````md
 <figure id="figure-gen">Dynamically Rendered Diagram</figure>
@@ -542,7 +553,7 @@ Then you may only need to use HTML for dynamically rendered figures, e.g. a Plan
 ```
 ````
 
-To compile both figures into the same list one way to configure glossarify-md is to declare a `listOf` class *figure* (for HTML elements) and tell `listOfFigures` (for `![]()` images) to use the same classifier *figure*:
+To compile both figures into the same list one way to configure [glossarify-md] is to declare a `listOf` class *figure* (for HTML elements) and tell `listOfFigures` (for `![]()` images) to use the same classifier *figure*:
 
 *glossarify-md.conf.json* (since v5.0.0)
 
@@ -587,7 +598,7 @@ This configuration which would allow you to also choose a shorter classifier lik
 }
 ```
 
-In contrast to images Markdown tables have no notion of a table caption. To render a list item for a table glossarify-md tries to infer a list item label.
+In contrast to images Markdown tables have no notion of a table caption. To render a list item for a table [glossarify-md] tries to infer a list item label.
 
 One such inference looks at the **paragraph preceding the table**. If it **ends with an *emphasized* phrase** and the phrase itself is **terminated by a colon** then the tool uses that phrase as the item label:
 
@@ -639,7 +650,7 @@ The result for the tables above will be:
 > - [Average Prices by Article Category](#avg-prices)
 
 
-**Since v5.0.0** and the introduction of `listOf` all the previous examples will make glossarify-md annotate the table with an HTML anchor. So while not recommended due to verbosity, you could of course also just add an HTML anchor yourself, like described in [`listOf`](#lists):
+**Since v5.0.0** and the introduction of `listOf` all the previous examples will make [glossarify-md] annotate the table with an HTML anchor. So while not recommended due to verbosity, you could of course also just add an HTML anchor yourself, like described in [`listOf`](#lists):
 
 ```md
 <a id="avg-prices" class="table" title="Average Prices by Article Category"></a>
@@ -651,7 +662,7 @@ The result for the tables above will be:
 | 3        | Book        | $23.45     |
 ```
 
-> **ⓘ Note:** If glossarify-md can't find a list item label by any of the above means it will fall back to rendering a list item
+> **ⓘ Note:** If [glossarify-md] can't find a list item label by any of the above means it will fall back to rendering a list item
 > 1. using the table headers separated by comma,
 > 1. or if no headers, using the closest section heading
 > 1. or if no section heading, using the file name.
@@ -698,15 +709,15 @@ If the regular expression (RegExp) matches text in a paragraph, then *the paragr
 
 > **ⓘ When to consider "markdown syntax" in the RegExp**:
 >
-> You may noticed that the RegExp above doesn't assume *Task:* to be written between "bold" star markers `**`. The expression won't be matched against the input *you* wrote but against *plain text* cleaned from symbols contributing to CommonMark or GFM syntax.
+> You may noticed that the RegExp above doesn't assume *Task:* to be written between "bold" star markers `**`. The expression won't be matched against the input *you* wrote but against *plain text* cleaned from symbols contributing to [CommonMark] or [GFM] syntax.
 >
 > In case you use another Markdown flavor see our addendum on [Markdown Syntax Extensions][doc-syntax-extensions]. Without a proper plug-in its syntactical elements are likely considered plain text, too. Then they need to be taken care of in the RegExp to make it match.
 
 ## Structured Export and Import
 [doc-export-import]: #structured-export-and-import
-SKOS: https://w3.org/skos
+[SKOS]: https://w3.org/skos
 
-**Since v6.0.0** glossary terms can be exported to a structured JSON format (file extension `.json`). When jsonld is installed alongside glossarify-md then terms can also be exported to RDF N-Quads (file extension `.nq`).
+**Since v6.0.0** glossary terms can be exported to a structured JSON format (file extension `.json`). When [jsonld] is installed alongside glossarify-md then terms can also be exported to RDF N-Quads (file extension `.nq`).
 
 *glossarify-md.conf.json* (generates ./glossary.json)
 ~~~json
@@ -721,7 +732,7 @@ SKOS: https://w3.org/skos
 }
 ~~~
 
-Declare a glossary `uri` when exporting. It will make glossarify-md assign each term a *uniform resource identifier* by combining the glossary's `uri` with a term's book-internal identifier (see [`headingIdAlgorithm`][headingIdAlgorithm]). Note that URIs are not required to resolve to some web page but *can* do so. More on the idea behind URIs read [here][doc-vocabulary-uris]. You can import terms the same way using `import` instead.
+Declare a glossary `uri` when exporting. It will make [glossarify-md] assign each term a *uniform resource identifier* by combining the glossary's `uri` with a term's book-internal identifier (see [`headingIdAlgorithm`][headingIdAlgorithm]). Note that URIs are not required to resolve to some web page but *can* do so. More on the idea behind URIs read [here][doc-vocabulary-uris]. You can import terms the same way using `import` instead.
 
 *glossarify-md.conf.json* (generates ./glossary.md):
 ~~~json
@@ -736,7 +747,7 @@ Declare a glossary `uri` when exporting. It will make glossarify-md assign each 
 }
 ~~~
 
-> ⚠ **Important:** glossarify-md is able to import JSON glossaries from a remote location using `https`. While it will try to remove any Markdown and HTML from imported term definitions using [strip-markdown](https://npmjs.com/package/strip-markdown) it can only do so after `JSON.parse()`. As a rule of thumb never import from untrusted sources and assume that any files from a remote location could enable a remote entity to embed malicious code into outputs or execute such code in the runtime context of glossarify-md. Consider importing files statically after review.
+> ⚠ **Important:** [glossarify-md] is able to import JSON glossaries from a remote location using `https`. While it will try to remove any Markdown and HTML from imported term definitions using [strip-markdown](https://npmjs.com/package/strip-markdown) it can only do so after `JSON.parse()`. As a rule of thumb never import from untrusted sources and assume that any files from a remote location could enable a remote entity to embed malicious code into outputs or execute such code in the runtime context of [glossarify-md]. Consider importing files statically after review.
 
 Advanced topics on importing and exporting can be found [here](https://github.com/about-code/glossarify-md/blob/master/doc/skos-interop.md).
 
@@ -747,7 +758,7 @@ The term *support* refers to *runs on the given platform* and is subject to the 
 
 | NodeJS  | glossarify-md |                                                                           Current Test Matrix                                                                            |
 | ------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Current | v6+           | Tested. Should node.js introduce breaking changes which affect glossarify-md, then we may choose to step back from supporting *Current* until it becomes the next LTS. |
+| Current | v6+           | Tested. Should node.js introduce breaking changes which affect [glossarify-md], then we may choose to step back from supporting *Current* until it becomes the next LTS. |
 | 16 LTS  | v5, v6+       | Tested + Supported                                                                                                                                                       |
 | 14 LTS  | v4, v5, v6+   | Tested + Supported                                                                                                                                                       |
 | 12 LTS  | v3, v4, v5    |                                                                                                                                                                          |
@@ -997,7 +1008,7 @@ Whether to convert inline-links to [link reference definitions] (size-efficient)
 - **Default:** `true`
 - **Since:** v6.0.0
 
-Whether to linkify headings. Note that some Markdown-to-HTML renderers need headings to be linkified in order to be rendered URL-addressable and navigable. Others like pandoc don't need linkified headings but special syntax.
+Whether to linkify headings. Note that some Markdown-to-HTML renderers need headings to be linkified in order to be rendered URL-addressable and navigable. Others like [pandoc] don't need linkified headings but special syntax.
 
 See also:
 
@@ -1042,9 +1053,9 @@ where `baseUrl` will be used only if there's no glossary uri. The `*-7` hashsum 
 - **Default:** false
 - **Since:** v6.0.0
 
-Since v5 there has been support for *parsing* pandoc-style heading IDs from input markdown. In v6 we added support for *writing*  pandoc-style `{#id}` identifiers to output markdown to facilitate postprocessing with pandoc.
+Since v5 there has been support for *parsing* pandoc-style heading IDs from input markdown. In v6 we added support for *writing*  pandoc-style `{#id}` identifiers to output markdown to facilitate postprocessing with [pandoc].
 
-> **ⓘ Note:** Pandoc's identifier syntax is not standardized in CommonMark.
+> **ⓘ Note:** Pandoc's identifier syntax is not standardized in [CommonMark].
 
 See also
 

--- a/md/doc/README.md
+++ b/md/doc/README.md
@@ -7,13 +7,6 @@
 [doc-pandoc]: ./pandoc.md
 [doc-plugins]: ./plugins.md
 [doc-glossary]: ./glossary.md
-[SKOS]: http://w3.org/skos/
-[LD]: https://www.w3.org/standards/semanticweb/ontology
-[JSON-LD]: https://json-ld.org
-[jsonld]: https://npmjs.com/package/jsonld
-[vocabularies]: https://www.w3.org/standards/semanticweb/ontology
-[glossarify-md]: https://github.com/about-code/glossarify-md
-[OWL]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/
 
 # Advanced Topics
 

--- a/md/doc/README.md
+++ b/md/doc/README.md
@@ -1,32 +1,66 @@
-[doc-vocabulary-uris]: ./vocabulary-uris.md
-[doc-skos-interop]: ./skos-interop.md
-[doc-vuepress]: ./vuepress.md
-[doc-syntax-extensions]: ./markdown-syntax-extensions.md
 [doc-conceptual-layers]: ./conceptual-layers.md
+[doc-glossary]: ./glossary.md
 [doc-lists-on-github]: ./lists-on-github.md
 [doc-pandoc]: ./pandoc.md
+[doc-path-rewriting]: ./path-rewriting.md
 [doc-plugins]: ./plugins.md
-[doc-glossary]: ./glossary.md
+[doc-vocabulary-uris]: ./vocabulary-uris.md
+[doc-vuepress]: ./vuepress.md
+[doc-references]: ./references.md
+[doc-skos-interop]: ./skos-interop.md
+[doc-syntax-extensions]: ./markdown-syntax-extensions.md
+[README.md]: ../README.md
 
-# Advanced Topics
+# Documentation
 
-[Glossary][doc-glossary] (of glossarify-md)
+Alternative Table of Contents for [README.md].
+Sections marked with * add content *not* found in the README.
 
-Markdown Syntax
-- [Markdown Syntax Extensions][doc-syntax-extensions]
-- [Installing Syntax Plug-ins][doc-plugins]
+Setup
+- [Install](../README.md#install)
+- [Configuration](./README.md#configuration)
+  - [Options](../README.md#options)
+- [Node Support Matrix](../README.md#node-support-matrix)
 
-Exporting and Importing
-- [URIs as Identifiers for Definitions of Meaning][doc-vocabulary-uris]
-- [Interoperability with SKOS and JSON-LD][doc-skos-interop]
+Glossary Basics
+- [Basic Glossary Example](../README.md#sample)
+- [Aliases and Synonyms](../README.md#aliases-and-synonyms)
+- [Term Hints](../README.md#term-hints)
+- [Multiple Glossaries](../README.md#multiple-glossaries)
+- [Sorting Glossaries](../README.md#sorting-glossaries)
 
+Book Writing
 
-Further Processing
-- [Using glossarify-md with vuepress][doc-vuepress]
-- [Using glossarify-md with pandoc][doc-pandoc]
+- [Cross Linking](../README.md#cross-linking)
+  - [Term-Based Auto-Linking](../README.md#term-based-auto-linking)
+  - [Identifier-based Cross-Linking](../README.md#identifier-based-cross-linking)
+- [References*][doc-references]
+- [Book Index](../README.md#book-index)
+- [Lists](../README.md#lists)
+  - [List of Figures](../README.md#list-of-figures)
+  - [List of Tables](../README.md#list-of-tables)
+  - [Lists from Regular Expressions](../README.md#lists-from-regular-expressions)
 
-Internals
-- [Conceptual Layers of glossarify-md][doc-conceptual-layers]
+Publishing
+- [Using glossarify-md with vuepress*][doc-vuepress]
+- [Using glossarify-md with pandoc*][doc-pandoc]
+- [Path Rewriting*][doc-path-rewriting]
+
+Exporting and Importing Terms
+- [Basics](../README.md#structured-export-and-import)
+- [URIs as Identifiers for Definitions of Meaning*][doc-vocabulary-uris]
+- [Interoperability with SKOS and JSON-LD*][doc-skos-interop]
+
+Dealing with Non-Standard Markdown Syntax
+- [Markdown Syntax Extensions*][doc-syntax-extensions]
+- [Installing Syntax Plug-ins*][doc-plugins]
+
+Glossary
+- [Glossary*][doc-glossary] (of [glossarify-md…][1])
+
+Developer Resources
+- [Conceptual Layers of glossarify-md*][doc-dev-conceptual-layers]
+- [The Parsing Process and Custom Node Types*][doc-dev-node-types]
 
 Known Issues
-- [Generated Lists and Links on GitHub][doc-lists-on-github]
+- [Generated Lists and Links on GitHub*][doc-lists-on-github]

--- a/md/doc/README.md
+++ b/md/doc/README.md
@@ -44,7 +44,6 @@ Book Writing
 Publishing
 - [Using glossarify-md with vuepress*][doc-vuepress]
 - [Using glossarify-md with pandoc*][doc-pandoc]
-- [Path Rewriting*][doc-path-rewriting]
 
 Exporting and Importing Terms
 - [Basics](../README.md#structured-export-and-import)
@@ -56,7 +55,7 @@ Dealing with Non-Standard Markdown Syntax
 - [Installing Syntax Plug-ins*][doc-plugins]
 
 Glossary
-- [Glossary*][doc-glossary] (of [glossarify-md…][1])
+- [Glossary*][doc-glossary] (Terms of glossarify-md)
 
 Developer Resources
 - [Conceptual Layers of glossarify-md*][doc-dev-conceptual-layers]

--- a/md/doc/_references.md
+++ b/md/doc/_references.md
@@ -1,0 +1,129 @@
+# References
+
+## Atom
+<!--{"uri": "https://atom.io" }-->
+Atom Code Editor.
+
+## CommonMark
+<!--{ "uri": "https://commonmark.org" }-->
+Effort on providing a minimal set of standardized Markdown syntax.
+
+## Dublin Core
+<!--{
+    "uri": "http://purl.org/dc/terms/",
+    "aliases": "DC, DublinCore, dc:"
+}-->
+The Dublin Core Metadata Initiative.
+
+## GFM
+<!--{
+    "uri": "https://github.github.com/gfm/",
+    "aliases": "GFM, GitHub Flavoured Markdown, GitHub Flavored Markdown"
+}-->
+GitHub Flavoured Markdown
+
+## github-slugger
+<!--{"uri": "https://npmjs.com/package/github-slugger" }-->
+A library providing support for slugs. See github-slugger.
+
+## glob
+<!--{"uri": "https://github.com/isaacs/node-glob#glob-primer" }-->
+A file pattern matcher. See glob.
+
+## glossarify-md
+<!--{"uri": "https://github.com/about-code/glossarify-md" }-->
+This project.
+
+## Jekyll
+<!--{"uri": "https://jekyllrb.com" }-->
+A static website renderer compiling an HTML website from Markdown files.
+
+## JSON-LD
+<!--{
+    "uri": "https://json-ld.org",
+    "aliases": "JSON-LD Spec"
+}-->
+
+JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. SKOS is one such vocabulary supported by glossarify-md
+
+## jsonld Library
+<!--{
+    "uri": "https://npmjs.com/package/jsonld",
+    "aliases": "jsonld"
+}-->
+A JavaScript implementation of JSON-LD.
+
+## Linked Data
+<!--{
+    "uri": "https://www.w3.org/standards/semanticweb/ontology",
+    "aliases": "LD"
+}-->
+See Linked Data.
+
+## mdAst
+<!--{
+    "uri": "https://github.com/syntax-tree/mdast",
+    "aliases": "mdAST, mdast"
+}-->
+
+Specification and Implementation of a Markdown Abstract Syntax Tree.
+
+## micromark
+<!--{"uri": "https://github.com/micromark/" }-->
+
+A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing).
+
+## npm
+<!-- {"uri": "https://npmjs.com"}-->
+
+Node Package Manager. See npm.
+
+## OWL
+<!--{"uri": "https://www.w3.org/TR/2012/REC-owl2-overview-20121211/" }-->
+
+Web Ontology Language.
+
+## pandoc
+<!--{"uri": "https://pandoc.org" }-->
+
+See pandoc.
+
+## PlantUML
+<!--{"uri": "https://plantuml.com" }-->
+Generates diagrams from text files written in the PlantUML syntax.
+
+## remark
+<!--{"uri": "https://github.com/remarkjs/remark" }-->
+
+*remark* is a parser and compiler project under the unified umbrella for *Markdown* text files in particular.
+
+
+## SKOS
+<!--{ "uri": "http://w3.org/skos/" }-->
+
+With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
+
+## unified
+<!--{ "uri": "https://unifiedjs.com" }-->
+
+*unified* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md](./conceptual-layers.md)
+
+## URN
+<!--{ "uri": "https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml" }-->
+Uniform Resource Names. See URN.
+
+## VSCode
+<!--{ "uri": "https://code.visualstudio.com" }-->
+[Code-OSS]: https://github.com/microsoft/vscode
+
+Visual Studio Code. See VSCode or [Code-OSS].
+
+## vuepress
+<!--{"uri": "https://vuepress.vuejs.org" }-->
+
+A static website generator translating markdown files into a website powered by [vuejs].
+
+## vuejs
+<!--{"uri": "https://vuejs.org" }-->
+
+A Single Page Application framework written in JavaScript.

--- a/md/doc/conceptual-layers.md
+++ b/md/doc/conceptual-layers.md
@@ -10,7 +10,7 @@ Conceptual layers of text processing by glossarify-md and projects contributing 
 | ----- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 4     | glossarify-md | cross-linking multiple markdown files                                                                                                                                 |
 | 3     | unified       | umbrella project for *text file processing in general*                                                                                                                |
-| 2     | remark        | unified *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree ([mdast]) data structure grown from micromark tokens. |
+| 2     | remark        | unified *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree (mdAst) data structure grown from micromark tokens. |
 | 1     | micromark     | remarks internal markdown syntax tokenizer                                                                                                                            |
 | 0     | CommonMark    | Markdown Syntax Specification                                                                                                                                         |
 

--- a/md/doc/conceptual-layers.md
+++ b/md/doc/conceptual-layers.md
@@ -1,27 +1,20 @@
 # Internals: Conceptual Layers
 
-[CommonMark]: https://commonmark.org
 [doc-syntax-extensions]: ./markdown-syntax-extensions.md
-[GFM]: https://github.github.com/gfm/
-[glossarify-md]: https://github.com/about-code/glossarify-md
-[mdast]: https://github.com/syntax-tree/mdast
-[micromark]: https://github.com/micromark/
-[remark]: https://github.com/remarkjs/remark
 [remark-gfm]: https://npmjs.com/package/remark-gfm
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
-[unified]: https://unifiedjs.com
 
-Conceptual layers of text processing by [glossarify-md] and projects contributing to each layer
+Conceptual layers of text processing by glossarify-md and projects contributing to each layer
 
-| Layer |     Project     |                          Conceptual purpose                           |
-| ----- | --------------- | --------------------------------------------------------------------- |
-| 4     | [glossarify-md] | cross-linking multiple markdown files                                 |
-| 3     | [unified]       | umbrella project for *text file processing in general*                |
-| 2     | [remark]        | unified *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree ([mdast]) data structure grown from micromark tokens.|
-| 1     | [micromark]     | remarks internal markdown syntax tokenizer                            |
-| 0     | [CommonMark]    | Markdown Syntax Specification                                         |
+| Layer |    Project    |                                                                          Conceptual purpose                                                                           |
+| ----- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 4     | glossarify-md | cross-linking multiple markdown files                                                                                                                                 |
+| 3     | unified       | umbrella project for *text file processing in general*                                                                                                                |
+| 2     | remark        | unified *processor* for *markdown text file processing in particular*. Offers access to an Abstract Syntax Tree ([mdast]) data structure grown from micromark tokens. |
+| 1     | micromark     | remarks internal markdown syntax tokenizer                                                                                                                            |
+| 0     | CommonMark    | Markdown Syntax Specification                                                                                                                                         |
 
 
-[glossarify-md] is built on [unified], an umbrella project for *text file processing in general*. We use unified with [remark] which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) [micromark] which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. [micromark] can be considered a technical implementation of the textual [CommonMark] specification.
+glossarify-md is built on unified, an umbrella project for *text file processing in general*. We use unified with remark which in conceptual terms of unified is a *processor* for *Markdown text files in particular*. remark itself is built on (or better *wrapping around*) micromark which is a low-level parser/tokenizer operating on a stream of individual character symbols which drive a token state machine. micromark can be considered a technical implementation of the textual CommonMark specification.
 
-When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required [micromark] extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in [glossarify-md] already installs itself is [remark-gfm] which adds support for the popular CommonMark syntax extension [GitHub Flavoured Markdown][GFM] (tables, footnotes and more).
+When looking for non-standard [syntax extensions][doc-syntax-extensions] you should be looking for [remark plug-ins][remark-plugins]. Those plug-ins are likely to depend on and transitively install their preferred or required micromark extension themselves. Others may operate on layer 2 using a simpler RegEx parsing. One plug-in glossarify-md already installs itself is [remark-gfm] which adds support for the popular CommonMark syntax extension GitHub Flavoured Markdown (tables, footnotes and more).

--- a/md/doc/glossary.md
+++ b/md/doc/glossary.md
@@ -1,44 +1,16 @@
-# Glossary of glossarify-md
-[glossarify-md]: https://github.com/about-code/glossarify-md
+# Glossary
+
+glossarify-md: https://github.com/about-code/glossarify-md
 
 This is a glossary of terms helpful when working with glossarify-md or reading its docs. It also servers as an example and is processed by *glossarify-md* itself using the [glossarify-md.conf.json](../glossarify-md.conf.json) configuration at the root of this repo.
 
-## JSON-LD
-[JSON-LD]: https://json-ld.org
-[jsonld]: https://npmjs.com/package/jsonld
-[LD]: https://www.w3.org/standards/semanticweb/ontology
+## Alias
 
-[JSON-LD] is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. SKOS is one such vocabulary supported by [glossarify-md]
+A sementically similar or equivalent alternative name for a term. May also be used to link grammatical variants of a term with a term definition.
 
-## KOS (Knowledge Organization Systems)
-<!--{ "aliases": "KOS, Knowledge Organization System" }-->
-[vocabularies]: https://www.w3.org/standards/semanticweb/ontology
-[OWL]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/
+## Term
 
-Glossaries are considered a kind of *Knowledge Organisation System (KOS)* which organizes knowledge as a list of terms and term definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed SKOS.
-
-[Formal Ontologies][vocabularies] are graph-like KOS which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the [*Web Ontology Language* OWL][OWL]. SKOS was built on top of OWL.
-
-## Linkification
-
-Process of searching for a term in *document A* matching a heading phrase in
-*document B* and replacing the term in *document A* with a Markdown link pointing
-onto the term definition in *document B*.
-
-## remark
-[remark]: https://github.com/remarkjs/remark
-
-[remark] is a parser and compiler project under the unified umbrella for *Markdown* text files in particular.
-
-## SKOS
-[SKOS]: http://w3.org/skos/
-
-With [SKOS](https://w3.org/skos) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
-
-## slug
-<!--{ "aliases": "slugs" }-->
-
-A slug by our definition is a URL-friendly identifier created from arbitrary text that can be used within URL fragments to address headings / sections on a page.
+A term is a heading in a markdown file which is passed to glossarify-md as a glossary.
 
 ## Term Attributes
 <!--{ "uri": "term attribute, term-attribute" }-->
@@ -58,12 +30,22 @@ Term Attributes are properties passed to glossarify-md using an HTML comment syn
 An optional (symbol-) character like for example `🟉` decorating a term link to distinguish it from a regular link.
 See glossarify-md configuration options for details.
 
+## Vocabulary
+<!--{ "aliases": "vocabularies, Formal Ontologies" }-->
+[vocabularies]: https://www.w3.org/standards/semanticweb/ontology
 
-## unified
-[unified]: https://unifiedjs.com
+A collection of terms which is uniquely identifiable. See also [Semantic Web Vocabularies and Ontologies][vocabularies].
 
-[unified] is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md](./conceptual-layers.md)
+## Linkification
 
+Process of searching for a term in *document A* matching a heading phrase in
+*document B* and replacing the term in *document A* with a Markdown link pointing
+onto the term definition in *document B*.
+
+## Slug
+<!--{ "aliases": "slug, slugs" }-->
+
+A slug is a URL-friendly identifier that can be used within URL fragments to address headings / sections on a page.
 
 ## URL fragment
 <!-- Aliases: URL fragments -->
@@ -73,24 +55,10 @@ The fragment is the part follwing the `#` in a URL.
 <!--{ "aliases": "URI, URL" }-->
 
 *Uniform Resource Identifier* and *Uniform Resource Locator* are both the same thing, which is an ID with a syntax `scheme://authority.tld/path/#fragment?query` like `https://my.org/foo/#bar?q=123`. Although both things are the same, the two acronyms are often used to emphasize whether using the ID to primarily *identify* something or using *the same ID* to *also* locate and retrieve a represention of what it identifies.
-<!--
-For example there's no strict requirement that URIs must resolve to a web page. They are just IDs. However URIs *can* be used to *locate and retrieve* a textual representation *of what they identify* which is when they are often called URL. A *representation* can be a web page. But an URI could als identify a technical device and could be used as an URL to locate a representation of that device in form of a datasheet.
 
-URIs continue to be IDs after a particular representation like the datasheet disappears. This sometimes leads to controversies on whether a certain URL which is also an URI can ever be "reused" to locate something different than what the URI identified.
+## KOS - Knowledge Organization Systems
+<!--{ "aliases": "KOS, Knowledge Organization System" }-->
 
-Strictly spoken: it *should not* because URLs and URIs *are equivalent* and two sides of the same coin. A URL should be reserved to locate and serve a representation of what itself *being a URI* identifies. If it doesn't it no longer identifies *a single* thing but two different things and loses its purpose as *identifier*.
+Glossaries are considered a kind of *Knowledge Organisation System (KOS)* which organizes knowledge as a list of terms and term definitions. There are other KOS like *Thesauri*, *Taxonomies* or *Word Nets* which add term relationships (hierarchically or as graphs capturing semantic or linguistic relationships). To model informal KOS the W3C has developed SKOS.
 
-However, it is a matter of fact that URLs and the web page content they identify and locate change thousands of times every day world wide. Because often it simply doesn't matter *what exactly* an URI/URL identifies but just that it identifies and locates *something*. Therefore you may only really care about "durability" of an URI/URL if your audience cares or if you really want to identify a particular thing.
-
-If you're afraid of making a long-term comittment on a particular URI because you "might want to reuse the URL", then there's a simple solution: just add additional elements like "time", "randomness" or "uniqueness" to the URI/URL's `/path/...` or `#fragment` part to make it *unlikely* of being reused for something else.
-
-In case of glossarify-md you could use one of the cryptographic heading ID algorithms like `md5` or `sha256` supported by [`headingIdAlgorithm`][headingIdAlgorithm].
-
-[headingIdAlgorithm]: ../README.md#linkingheadingidalgorithm
--->
-
-## vuepress
-[vuepress]: https://vuepress.vuejs.org
-[vuejs]: https://vuejs.org
-
-[vuepress] is a static website generator translating markdown files into a website powered by [vuejs].
+Formal Ontologies are graph-like KOS which focus on *logical formalism*. They are built from logical statements and tend to become harder to maintain as they grow due to a requirement of being *fully free of logical conflicts*. Ontologies require a (meta-) vocabulary known as the *Web Ontology Language* OWL. SKOS was built on top of OWL.

--- a/md/doc/glossary.md
+++ b/md/doc/glossary.md
@@ -13,7 +13,7 @@ A sementically similar or equivalent alternative name for a term. May also be us
 A term is a heading in a markdown file which is passed to glossarify-md as a glossary.
 
 ## Term Attributes
-<!--{ "uri": "term attribute, term-attribute" }-->
+<!--{ "aliases": "term attribute, term-attribute" }-->
 
 Term Attributes are properties passed to glossarify-md using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
 

--- a/md/doc/glossary.md
+++ b/md/doc/glossary.md
@@ -12,8 +12,8 @@ A sementically similar or equivalent alternative name for a term. May also be us
 
 A term is a heading in a markdown file which is passed to glossarify-md as a glossary.
 
-## Term Attributes
-<!--{ "aliases": "term attribute, term-attribute" }-->
+## Term Attribute
+<!--{ "aliases": "term attributes, term-attribute" }-->
 
 Term Attributes are properties passed to glossarify-md using an HTML comment syntax `<!--{...}-->` which encodes a JSON string:
 

--- a/md/doc/lists-on-github.md
+++ b/md/doc/lists-on-github.md
@@ -1,12 +1,9 @@
 # Known Issues: Lists in GitHub Repos
 
 [doc-readme-lists]: ../README.md#lists
-[glossarify-md]: https://github.com/about-code/glossarify-md
 [gfm-sanitize]: https://github.github.com/gfm/#what-is-github-flavored-markdown-
 [gh-pages]: https://pages.github.com/
 [html-sem-tags]: https://www.w3schools.com/html/html5_semantic_elements
-[Jekyll]: https://jekyllrb.com
-[vuepress]: https://vuepress.vuejs.org
 [2]: <>
 
 Addendum to [Section *Lists* in README.md][doc-readme-lists]
@@ -29,6 +26,6 @@ Normally, when converting such markdown to HTML using a Markdown-to-HTML static 
 
 On a GitHub repository, though, you'll find that you can navigate within the repository using the list item link in `list.md` but the browser *won't* scroll to the item position `#mylist-foo` in `page.md`. The reason for this is that GitHub *[sanitizes][gfm-sanitize]* Markdown files before rendering them within their own repository previews. They allow only a small subset of HTML and strip elements like `<cite>` and other [Semantic HTML Tags][html-sem-tags] including the element's `id="#mylist-foo"` which a browser needs to be able to scroll to that part of an HTML document. Therefore, if you care for navigability in GitHub repositories, just use supported elements like `<span>` or `<a>` instead.
 
-**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in [glossarify-md]. For example, if you were rendering `list.md` and `page.md` with a static website generator like [Jekyll] or [vuepress] things work just fine.
+**This is a limitation of GitHub's repository preview renderer *only*!** It is not a bug in glossarify-md. For example, if you were rendering `list.md` and `page.md` with a static website generator like Jekyll or vuepress things work just fine.
 
-You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to https://yoursite.github.io using [Jekyll].
+You can even try yourself with [GitHub Pages][gh-pages] which renders `.md` files in a repo to https://yoursite.github.io using Jekyll.

--- a/md/doc/markdown-syntax-extensions.md
+++ b/md/doc/markdown-syntax-extensions.md
@@ -5,9 +5,8 @@
 [remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
-vuepress: https://vuepress.vuejs.org
 
-glossarify-md supports CommonMark and [GitHub Flavoured Markdown (GFM)][GFM]. Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's [Abstract Syntax Tree][mdast]. As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
+glossarify-md supports CommonMark and GitHub Flavoured Markdown (GFM). Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's Abstract Syntax Tree (mdAst). As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
 
 *Frontmatter Syntax*
 

--- a/md/doc/markdown-syntax-extensions.md
+++ b/md/doc/markdown-syntax-extensions.md
@@ -2,19 +2,12 @@
 
 [doc-conceptual-layers]: ./conceptual-layers.md
 [doc-plugins]: ./plugins.md
-[CommonMark]: https://www.commonmark.org
-[GFM]: https://github.github.com/gfm/
-[glossarify-md]: https://github.com/about-code/glossarify-md
-[mdast]: https://github.com/syntax-tree/mdast
-[micromark]: https://github.com/micromark/
-[remark]: https://github.com/remarkjs/remark
 [remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
 [remark-plugins]: https://github.com/remarkjs/awesome-remark
-[unified]: https://unifiedjs.com
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
-[vuepress]: https://vuepress.vuejs.org
+vuepress: https://vuepress.vuejs.org
 
-[glossarify-md] supports [CommonMark] and [GitHub Flavoured Markdown (GFM)][GFM]. Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's [Abstract Syntax Tree][mdast]. As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
+glossarify-md supports CommonMark and [GitHub Flavoured Markdown (GFM)][GFM]. Syntax not covered by these specifications may have no or worse, a wrong representation in the tool's [Abstract Syntax Tree][mdast]. As a consequence it may not make it correctly into output documents. For example *Frontmatter* syntax is a Markdown syntax extension popularized by many static site generators:
 
 *Frontmatter Syntax*
 
@@ -24,6 +17,6 @@ key: This is a frontmatter
 ---
 ```
 
-Without special support for it [CommonMark] compliant parsers like our [remark] parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
+Without special support for it CommonMark compliant parsers like our remark parser will interpret the line of trailing dashes as *heading* markers and the text before them as *heading text*. So to make our parser aware of frontmatter syntax we need to enhance it.
 
-**Since v5.0.0** we have opened [glossarify-md] to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].
+**Since v5.0.0** we have opened glossarify-md to the [remark plug-in ecosystem][remark-plugins] and its support of additional syntaxes and tools. More see [Installing Plug-ins][doc-plugins].

--- a/md/doc/pandoc.md
+++ b/md/doc/pandoc.md
@@ -1,7 +1,5 @@
 # Using glossarify-md with pandoc
 
-[pandoc]: https://pandoc.org
-
 ~~~
 ${root}
    +- docs/
@@ -37,7 +35,7 @@ npm i --save glossarify-md
 }
 ~~~
 
-When [pandoc] merges multiple files into a single file we need to take care for
+When pandoc merges multiple files into a single file we need to take care for
 link stability and paths.
 
 1. `linking.paths: "none"` disables the use of paths and uses heading ids

--- a/md/doc/plugins.md
+++ b/md/doc/plugins.md
@@ -1,14 +1,10 @@
 # Installing Syntax Plug-ins
 
 [doc-conceptual-layers]: ./conceptual-layers.md
-CommonMark: https://www.commonmark.org
-glossarify-md: https://github.com/about-code/glossarify-md
 [mdast-util-visit]: https://npmjs.com/package/mdast-util-visit
-micromark: https://github.com/micromark/
 [remark-discussion]: https://github.com/remarkjs/remark/discussions/869#discussioncomment-1602674
 [remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
 [remark-plugin]: https://github.com/remarkjs/awesome-remark
-unified: https://unifiedjs.com
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
 

--- a/md/doc/plugins.md
+++ b/md/doc/plugins.md
@@ -1,23 +1,20 @@
 # Installing Syntax Plug-ins
 
 [doc-conceptual-layers]: ./conceptual-layers.md
-[CommonMark]: https://www.commonmark.org
-[glossarify-md]: https://github.com/about-code/glossarify-md
-[mdast]: https://github.com/syntax-tree/mdast
+CommonMark: https://www.commonmark.org
+glossarify-md: https://github.com/about-code/glossarify-md
 [mdast-util-visit]: https://npmjs.com/package/mdast-util-visit
-[micromark]: https://github.com/micromark/
-[npm]: https://npmjs.com
-[remark]: https://github.com/remarkjs/remark
+micromark: https://github.com/micromark/
 [remark-discussion]: https://github.com/remarkjs/remark/discussions/869#discussioncomment-1602674
 [remark-frontmatter]: https://npmjs.com/package/remark-frontmatter
 [remark-plugin]: https://github.com/remarkjs/awesome-remark
-[unified]: https://unifiedjs.com
+unified: https://unifiedjs.com
 [unified-config]: https://github.com/unifiedjs/unified-engine/blob/main/doc/configure.md
 
 
-The following example demonstrates how to install a [remark plug-in][remark-plugin]. The plug-in will extend [glossarify-md]'s markdown parser [remark]  with support for *Frontmatter* syntax.
+The following example demonstrates how to install a [remark plug-in][remark-plugin]. The plug-in will extend glossarify-md's markdown parser remark  with support for *Frontmatter* syntax.
 
-> **☛ Note:** [glossarify-md] does not guarantee compatibility with plug-ins and likely won't help with issues arising due to installing and using additional third-party plug-ins.
+> **☛ Note:** glossarify-md does not guarantee compatibility with plug-ins and likely won't help with issues arising due to installing and using additional third-party plug-ins.
 
 We'll assume the following file structure:
 
@@ -67,17 +64,17 @@ npm install remark-frontmatter
 1. `remark-frontmatter` must be the name of the npm package you installed before
 2. any properties of the `remark-frontmatter` object are options specific to the plug-in.
 
-`remark.conf.json` follows the [unified configuration][unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *[glossarify-md]*'s config schema.
+`remark.conf.json` follows the [unified configuration][unified-config] schema. You could also embed the configuration into a `glossarify-md.conf.json` by replacing `rcPath` above with `plugins`. But keep in mind that anything under the `unified` key is a different config schema and *not* subject to *glossarify-md*'s config schema.
 
-> **ⓘ [remark], [unified], uhh... ?**
+> **ⓘ remark, unified, uhh... ?**
 >
-> Read more on how these projects relate to [glossarify-md] in [Conceptual Layers][doc-conceptual-layers].
+> Read more on how these projects relate to glossarify-md in [Conceptual Layers][doc-conceptual-layers].
 
 ## Writing a Plug-In
 
-Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this [remark discussion and little ASCII-art][remark-discussion] helpful. Have a look at [micromark] and [remark] for a reference, though.
+Above we saw how to install a *syntax plug-in* which are plug-ins that extend Markdown syntax itself. They operate on raw symbols and tokens and contribute new *node types* to an Abstract Syntax Tree (AST). If you aim to invent yet another non-standardized Markdown addition you might find this [remark discussion and little ASCII-art][remark-discussion] helpful. Have a look at micromark and remark for a reference, though.
 
-A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree ([mdAST][mdast]). [glossarify-md] itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
+A lot can be achieved by easier to write *tree plug-ins* which operate on and transform a markdown syntax tree ([mdAST][mdast]). glossarify-md itself operates on tree plug-ins, only (see [Conceptual Layers][doc-conceptual-layers]).
 
 A tree plug-in is a function which returns a callback that when called get's passed an [mdAST]:
 
@@ -99,7 +96,7 @@ export default function myPlugin(options = {}) {
 }
 ~~~
 
-The example uses a [visit][mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's URL and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of [CommonMark] node types see [mdAST].
+The example uses a [visit][mdast-util-visit] utility function for traversing the tree and calling a visitor on a node of `type: "link"` (to visit all nodes just pass the visitor as the second argument, instead). Once you have access to the tree you can transform it to your liking. The example will take a link node's URL and add a `&visited=true` URL query parameter. Not very useful but it illustrates the concept. Also note the `options` argument which is how your plug-in would get passed its config options. For a list of CommonMark node types see [mdAST].
 
 Here's how you can set up a plug-in project next to a glossarify-md project:
 
@@ -125,7 +122,7 @@ Here's how you can set up a plug-in project next to a glossarify-md project:
    npm install unist-util-visit
    ~~~
 
-You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to [npm]):
+You're now set with your plug-in. The next part will make your package usuable on your developer machine (since it's not yet published to npm):
 
 4. Within folder *remark-my-plugin* run
 
@@ -135,17 +132,17 @@ You're now set with your plug-in. The next part will make your package usuable o
 
    This creates a symlink in the system-global `node_modules` folder.
 
-5. `cd` into your [glossarify-md] project and create a symlink onto the global symlink:
+5. `cd` into your glossarify-md project and create a symlink onto the global symlink:
 
    ~~~
    npm link remark-my-plugin
    ~~~
 
-You now virtually "installed" your plug-in into your [glossarify-md] project similar as if you had run `npm install remark-my-plugin` to fetch it from the [npm] registry.
+You now virtually "installed" your plug-in into your glossarify-md project similar as if you had run `npm install remark-my-plugin` to fetch it from the npm registry.
 
-> **Important:** Be aware that step 5 needs to be repeated whenever you ran `npm install` in your [glossarify-md] project).
+> **Important:** Be aware that step 5 needs to be repeated whenever you ran `npm install` in your glossarify-md project).
 
-What's left is configuring [glossarify-md] to use it (see also previous section):
+What's left is configuring glossarify-md to use it (see also previous section):
 
 6. Add to your *glossarify-md.conf.json*
 

--- a/md/doc/references.md
+++ b/md/doc/references.md
@@ -1,12 +1,26 @@
-# References
+# Managing References
 
-## Atom
-<!--{"uri": "https://atom.io" }-->
-Atom Code Editor.
+In order to cite a source on the web whenever using a particular term, use a
+glossary configuration with `linkUris: true`:
 
+*glossarify-md.conf.json*
+~~~json
+{
+  "glossaries": [
+    {
+      "file": "./references.md",
+      "linkUris": true
+    }
+  ]
+}
+~~~
+
+Within file `./references.md` use the `uri` term attribute to provide the source's URL. Optionally you can add an `aliases` term attribute to make further terms refer to a particular source and provide a tooltip for the link.
+
+*references.md*
+~~~md
 ## CommonMark
 <!--{ "uri": "https://commonmark.org" }-->
-Effort on providing a minimal set of standardized Markdown syntax.
 
 ## Dublin Core
 <!--{
@@ -14,116 +28,6 @@ Effort on providing a minimal set of standardized Markdown syntax.
     "aliases": "DC, DublinCore, dc:"
 }-->
 The Dublin Core Metadata Initiative.
+~~~
 
-## GFM
-<!--{
-    "uri": "https://github.github.com/gfm/",
-    "aliases": "GFM, GitHub Flavoured Markdown, GitHub Flavored Markdown"
-}-->
-GitHub Flavoured Markdown
-
-## github-slugger
-<!--{"uri": "https://npmjs.com/package/github-slugger" }-->
-A library providing support for slugs. See github-slugger.
-
-## glob
-<!--{"uri": "https://github.com/isaacs/node-glob#glob-primer" }-->
-A file pattern matcher. See glob.
-
-## glossarify-md
-<!--{"uri": "https://github.com/about-code/glossarify-md" }-->
-This project.
-
-## Jekyll
-<!--{"uri": "https://jekyllrb.com" }-->
-A static website renderer compiling an HTML website from Markdown files.
-
-## JSON-LD
-<!--{
-    "uri": "https://json-ld.org",
-    "aliases": "JSON-LD Spec"
-}-->
-
-JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. SKOS is one such vocabulary supported by glossarify-md
-
-## jsonld Library
-<!--{
-    "uri": "https://npmjs.com/package/jsonld",
-    "aliases": "jsonld"
-}-->
-A JavaScript implementation of JSON-LD.
-
-## Linked Data
-<!--{
-    "uri": "https://www.w3.org/standards/semanticweb/ontology",
-    "aliases": "LD"
-}-->
-See Linked Data.
-
-## mdAst
-<!--{
-    "uri": "https://github.com/syntax-tree/mdast",
-    "aliases": "mdAST, mdast"
-}-->
-
-Specification and Implementation of a Markdown Abstract Syntax Tree.
-
-## micromark
-<!--{"uri": "https://github.com/micromark/" }-->
-
-A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing).
-
-## npm
-<!-- {"uri": "https://npmjs.com"}-->
-
-Node Package Manager. See npm.
-
-## OWL
-<!--{"uri": "https://www.w3.org/TR/2012/REC-owl2-overview-20121211/" }-->
-
-Web Ontology Language.
-
-## pandoc
-<!--{"uri": "https://pandoc.org" }-->
-
-See pandoc.
-
-## PlantUML
-<!--{"uri": "https://plantuml.com" }-->
-Generates diagrams from text files written in the PlantUML syntax.
-
-## remark
-<!--{"uri": "https://github.com/remarkjs/remark" }-->
-
-*remark* is a parser and compiler project under the unified umbrella for *Markdown* text files in particular.
-
-
-## SKOS
-<!--{ "uri": "http://w3.org/skos/" }-->
-
-With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
-
-## unified
-<!--{ "uri": "https://unifiedjs.com" }-->
-
-*unified* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md](./conceptual-layers.md)
-
-## URN
-<!--{ "uri": "https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml" }-->
-Uniform Resource Names. See URN.
-
-## VSCode
-<!--{ "uri": "https://code.visualstudio.com" }-->
-[Code-OSS]: https://github.com/microsoft/vscode
-
-Visual Studio Code. See VSCode or [Code-OSS].
-
-## vuepress
-<!--{"uri": "https://vuepress.vuejs.org" }-->
-
-A static website generator translating markdown files into a website powered by [vuejs].
-
-## vuejs
-<!--{"uri": "https://vuejs.org" }-->
-
-A Single Page Application framework written in JavaScript.
+See an example by inspecting the markdown source of [_references.md](./_references.md) or this repository's [glossarify-md.conf.json](../glossarify-md.conf.json).

--- a/md/doc/references.md
+++ b/md/doc/references.md
@@ -1,0 +1,129 @@
+# References
+
+## Atom
+<!--{"uri": "https://atom.io" }-->
+Atom Code Editor.
+
+## CommonMark
+<!--{ "uri": "https://commonmark.org" }-->
+Effort on providing a minimal set of standardized Markdown syntax.
+
+## Dublin Core
+<!--{
+    "uri": "http://purl.org/dc/terms/",
+    "aliases": "DC, DublinCore, dc:"
+}-->
+The Dublin Core Metadata Initiative.
+
+## GFM
+<!--{
+    "uri": "https://github.github.com/gfm/",
+    "aliases": "GFM, GitHub Flavoured Markdown, GitHub Flavored Markdown"
+}-->
+GitHub Flavoured Markdown
+
+## github-slugger
+<!--{"uri": "https://npmjs.com/package/github-slugger" }-->
+A library providing support for slugs. See github-slugger.
+
+## glob
+<!--{"uri": "https://github.com/isaacs/node-glob#glob-primer" }-->
+A file pattern matcher. See glob.
+
+## glossarify-md
+<!--{"uri": "https://github.com/about-code/glossarify-md" }-->
+This project.
+
+## Jekyll
+<!--{"uri": "https://jekyllrb.com" }-->
+A static website renderer compiling an HTML website from Markdown files.
+
+## JSON-LD
+<!--{
+    "uri": "https://json-ld.org",
+    "aliases": "JSON-LD Spec"
+}-->
+
+JSON-LD is a standardized JSON document format for mapping system-specific terms of a JSON-based data format to well-know terms from public vocabularies. With JSON-LD it's possible to write applications which are interoperable by mutual agreement on the same public vocabulary. SKOS is one such vocabulary supported by glossarify-md
+
+## jsonld Library
+<!--{
+    "uri": "https://npmjs.com/package/jsonld",
+    "aliases": "jsonld"
+}-->
+A JavaScript implementation of JSON-LD.
+
+## Linked Data
+<!--{
+    "uri": "https://www.w3.org/standards/semanticweb/ontology",
+    "aliases": "LD"
+}-->
+See Linked Data.
+
+## mdAst
+<!--{
+    "uri": "https://github.com/syntax-tree/mdast",
+    "aliases": "mdAST, mdast"
+}-->
+
+Specification and Implementation of a Markdown Abstract Syntax Tree.
+
+## micromark
+<!--{"uri": "https://github.com/micromark/" }-->
+
+A low-level extensible implementation of the CommonMark syntax specification (parsing and tokenizing).
+
+## npm
+<!-- {"uri": "https://npmjs.com"}-->
+
+Node Package Manager. See npm.
+
+## OWL
+<!--{"uri": "https://www.w3.org/TR/2012/REC-owl2-overview-20121211/" }-->
+
+Web Ontology Language.
+
+## pandoc
+<!--{"uri": "https://pandoc.org" }-->
+
+See pandoc.
+
+## PlantUML
+<!--{"uri": "https://plantuml.com" }-->
+Generates diagrams from text files written in the PlantUML syntax.
+
+## remark
+<!--{"uri": "https://github.com/remarkjs/remark" }-->
+
+*remark* is a parser and compiler project under the unified umbrella for *Markdown* text files in particular.
+
+
+## SKOS
+<!--{ "uri": "http://w3.org/skos/" }-->
+
+With the Simple Knowledge Organization System (SKOS) the World Wide Web Consortium (W3C) has standardized a (meta-)vocabulary which is suited and intended for modeling *Simple Knowledge Organization Systems* such as Glossaries, Thesauri, Taxonomies or Word Nets.
+
+## unified
+<!--{ "uri": "https://unifiedjs.com" }-->
+
+*unified* is an umbrella project around *text file processing in general*. See also [Conceptual Layers of glossarify-md](./conceptual-layers.md)
+
+## URN
+<!--{ "uri": "https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml" }-->
+Uniform Resource Names. See URN.
+
+## VSCode
+<!--{ "uri": "https://code.visualstudio.com" }-->
+[Code-OSS]: https://github.com/microsoft/vscode
+
+Visual Studio Code. See VSCode or [Code-OSS].
+
+## vuepress
+<!--{"uri": "https://vuepress.vuejs.org" }-->
+
+A static website generator translating markdown files into a website powered by [vuejs].
+
+## vuejs
+<!--{"uri": "https://vuejs.org" }-->
+
+A Single Page Application framework written in JavaScript.

--- a/md/doc/references.md
+++ b/md/doc/references.md
@@ -1,7 +1,6 @@
 # Managing References
 
-In order to cite a source on the web whenever using a particular term, use a
-glossary configuration with `linkUris: true`:
+In order to cite a source on the web whenever using a particular term use a glossary configuration with `linkUris: true`:
 
 *glossarify-md.conf.json*
 ~~~json
@@ -15,7 +14,7 @@ glossary configuration with `linkUris: true`:
 }
 ~~~
 
-Within file `./references.md` use the `uri` term attribute to provide the source's URL. Optionally you can add an `aliases` term attribute to make further terms refer to a particular source and provide a tooltip for the link.
+Within file `./references.md` use the term attribute `uri` to provide the source's URL. Optionally you can add an `aliases` term attribute to make further terms refer to a particular source and provide a tooltip for the link.
 
 *references.md*
 ~~~md

--- a/md/doc/skos-interop.md
+++ b/md/doc/skos-interop.md
@@ -1,25 +1,18 @@
 # Interoperability with SKOS and JSON-LD
 
-[glossarify-md]: https://github.com/about-code/glossarify-md
+glossarify-md: https://github.com/about-code/glossarify-md
 [doc-export-import]: ../README.md#structured-export-and-import
 [headingidalgorithm]: ../README.md#headingidalgorithm
-[SKOS]: http://w3.org/skos/
-[DC]: http://purl.org/dc/terms/
-[LD]: https://www.w3.org/standards/semanticweb/ontology
-[JSON-LD]: https://json-ld.org
-[JSON-LD Spec]: https://www.w3.org/TR/json-ld/
-[jsonld]: https://npmjs.com/package/jsonld
-[vocabularies]: https://www.w3.org/standards/semanticweb/ontology
-[OWL]: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/
+OWL: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/
 [sample-export]: ../test/output-expected/config-glossaries/export-and-glossary-uri/glossary.json
 
 > Readers Level: *Advanced*
 >
 > The term *term* can become itself confusing in this section. Therefore we'll say *model terms* if we refer to a vocabulary of technical attribute names or type names of a data model. We'll say *glossary terms* if we refer to the actual terms of a glossary (an instance of that data model).
 
-**Since v6.0.0** [glossarify-md] supports [exporting and importing][doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" [SKOS] and [Dublin Core][DC] model terms.
+**Since v6.0.0** glossarify-md supports [exporting and importing][doc-export-import] glossaries. In addition to importing terms from files exported by glossarify-md itself it can import glossary terms from arbitrarily structured JSON documents once there are mappings of the other document's *model terms* onto "well-known" SKOS and Dublin Core model terms.
 
-Model terms understood by [glossarify-md] are:
+Model terms understood by glossarify-md are:
 
 - `skos:ConceptScheme`
 - `skos:Concept`
@@ -45,7 +38,7 @@ To see how this works a good starting point is to have a look at a glossarify-md
 }
 ~~~
 
-The configuration will make [glossarify-md] produce a file
+The configuration will make glossarify-md produce a file
 
 *glossary.json*
 ~~~json
@@ -86,7 +79,7 @@ The configuration will make [glossarify-md] produce a file
 }
 ~~~
 
-`glossary.json` will embed a [JSON-LD] `@context` document. It maps glossarify-md's own export model terminology onto [SKOS] and [Dublin Core][DC] terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
+`glossary.json` will embed a [JSON-LD] `@context` document. It maps glossarify-md's own export model terminology onto SKOS and Dublin Core terms for interoperability with *other* tools understanding SKOS and Dublin Core.[^1]
 
 [^1]: You can map glossarify-md's terms onto other model vocabularies by adding a `context` attribute to the `export` config. The attribute value is expected to be a path to a `.json` or `.jsonld` file which exposes a document with a `@context` key.
 
@@ -108,9 +101,9 @@ Copy `glossary.json` which you've just exported into your input folder (*baseDir
 }
 ~~~
 
-Of course, [glossarify-md] will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
+Of course, glossarify-md will be able to import *its own* export format again. But what if you have terms exported by another tool in another format?
 
-> In case you just ran [glossarify-md] and there is an `imported.md` file in your `outDir` then delete it.
+> In case you just ran glossarify-md and there is an `imported.md` file in your `outDir` then delete it.
 
 Let's drop `@context` from `glossary.json` and change it to a very different schema:
 
@@ -132,9 +125,9 @@ Let's drop `@context` from `glossary.json` and change it to a very different sch
 }
 ~~~
 
-This is now a sample format *unknown* to [glossarify-md]. Different data formats and semantics like these are a barrier to *interoperability*. That's where JSON-LD and standardized vocabularies enter the game.
+This is now a sample format *unknown* to glossarify-md. Different data formats and semantics like these are a barrier to *interoperability*. That's where JSON-LD and standardized vocabularies enter the game.
 
-If the *unknown* application had embedded JSON-LD mappings onto [SKOS] and [DublinCore][DC] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
+If the *unknown* application had embedded JSON-LD mappings onto SKOS and [DublinCore] the data could have been understood right away. Since few tools do this as of today, we'll be writing these mappings on our own:
 
 *unknown-format.jsonld*
 ~~~json
@@ -176,9 +169,9 @@ What's left is to enhance glossarify-md with JSON-LD capabilities for interopera
 npm install jsonld
 ~~~
 
-[^2]: We could have installed [jsonld] together with [glossarify-md] by default but decided against to minimize bloat for the average user.
+[^2]: We could have installed [jsonld] together with glossarify-md by default but decided against to minimize bloat for the average user.
 
-On the next run [glossarify-md] will be looking for `@context` mappings
+On the next run glossarify-md will be looking for `@context` mappings
 
 1. *embedded into the JSON import file*
 2. or provided *externally* using `context` in the `import` config.
@@ -189,6 +182,6 @@ To sum up: we've just seen an example of interoperability and how two or more ap
 
 ### Additional Notes
 
-- [glossarify-md] will only import typed documents directly using JSON-LD's `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
+- glossarify-md will only import typed documents directly using JSON-LD's `@type` attribute or mapping their `type`-like attribute onto `@type`. Unknown type names need to be mapped onto `skos:ConceptScheme` (the glossary) and  `skos:Concept` (the terms).
 
-- More complicated data formats may require use of some additional [JSON-LD keywords][JSON-LD Spec].
+- More complicated data formats may require use of some additional JSON-LD keywords from the JSON-LD Spec.

--- a/md/doc/skos-interop.md
+++ b/md/doc/skos-interop.md
@@ -1,10 +1,6 @@
 # Interoperability with SKOS and JSON-LD
 
-glossarify-md: https://github.com/about-code/glossarify-md
 [doc-export-import]: ../README.md#structured-export-and-import
-[headingidalgorithm]: ../README.md#headingidalgorithm
-OWL: https://www.w3.org/TR/2012/REC-owl2-overview-20121211/
-[sample-export]: ../test/output-expected/config-glossaries/export-and-glossary-uri/glossary.json
 
 > Readers Level: *Advanced*
 >

--- a/md/doc/vocabulary-uris.md
+++ b/md/doc/vocabulary-uris.md
@@ -1,9 +1,8 @@
 # URIs as Identifiers for *Definitions of Meaning*
 
-[glossarify-md]: https://github.com/about-code/glossarify-md/
-[headingidalgorithm]: ../README.md#headingidalgorithm
-[iana-urns]: https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml
+[headingIdAlgorithm]: ../README.md#headingidalgorithm
 [doc-import]: ../README.md#structured-export-and-import
+[doc-skos]: ./skos-interop.md
 
 Consider bankers and IT professionals talking about *security*. Since the term is used differently in the banking domain than it is being used in computer science its *ambiguity* can cause some confusion among these people. As a consequence the term demands *clarification* of its particular meaning when being used. Of course, that's what glossaries are meant for.
 
@@ -16,7 +15,7 @@ it is clear that it refers to a different meaning than some identifier
 - `https://example.com/glossary/it/#security`.
 
 
-**Since v6.0.0** [glossarify-md] supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *vocabulary URI*. Then *exported* term URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingidalgorithm]).
+**Since v6.0.0** glossarify-md supports [exporting and importing][doc-import] glossaries. Moreover it introduces an `uri` option for `glossaries` which assigns a glossary a *vocabulary URI*. Then *exported* term URIs will be constructed from the vocabulary URI and a term's heading ID (see [headingIdAlgorithm]).
 
 ~~~json
 {
@@ -46,7 +45,7 @@ Term with an individual URI.
 
 ### Resolvability
 
-URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a term's URI could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make [glossarify-md] link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
+URIs can be *just identifiers*. But URIs can also be used to *locate and retrieve* representations of what they identify over a network protocol like HTTPS. For example, a web browser and a term's URI could be used to retrieve an HTML representation with a human readable definition of a term. A `glossaries` entry with `linkUris: true` will make glossarify-md link term occurrences with a *book-external* authoritative definition on the web rather than with the book-internal glossary. On [imported][doc-import] glossaries `showUris: true` or `showUris: "${uri}"` will render URI links in the markdown glossary generated from imported terms.
 
 ### Authority
 
@@ -55,7 +54,7 @@ URIs for terms reveal the authoritative source for a particular definition, whic
 
 
 <!--
-Uniform Resource Names (URNs) may be an alternative to URIs. They do not depend on the Domain Name System as a registry but on an [IANA registry of *URN namespaces*][iana-urns]:
+Uniform Resource Names (URNs) may be an alternative to URIs. They do not depend on the Domain Name System as a registry but on an IANA registry of *URN namespaces*:
 
 *URN with the `isbn` namespace registered by the International ISBN Agency*
 ~~~
@@ -70,4 +69,4 @@ urn:uuid:b3c38d70-3887-11ec-a63d-779a5e093fff
 ~~~
 -->
 
-If you have a background in Linked Data and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD](./skos-interop.md).
+If you have a background in Linked Data and Semantic Web technologies you might also be interested in reading about [SKOS Interoperability with JSON-LD][doc-skos].

--- a/md/doc/vuepress.md
+++ b/md/doc/vuepress.md
@@ -3,10 +3,6 @@
 Below we assume a *sample* project structure like this:
 
 [doc-syntax-extensions]: ./markdown-syntax-extensions.md
-[CommonMark]: https://www.commonmark.org
-[github-slugger]: https://npmjs.com/package/github-slugger
-[glossarify-md]: https://github.com/about-code/glossarify-md
-[vuepress]: https://vuepress.vuejs.org
 
 ```
 ${root}
@@ -55,7 +51,7 @@ npm i --save glossarify-md
 
 ## Configure vuepress
 
-[glossarify-md] and [vuepress] need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix](#appendix).
+glossarify-md and vuepress need to be aligned in terms of how they create section anchors. More on the *why* see [Appendix](#appendix).
 
 <em>./docs/.vuepress/config.js</em>
 ~~~js
@@ -73,7 +69,7 @@ module.exports = {
 };
 ~~~
 
-> ⚠ **Important:** Vuepress maps headings onto section anchors which become part of a URL fragment like `http://.../#foo-anchor`. By default vuepress creates anchors with lowercase ASCII characters, only. In contrast [github-slugger] will map unicode characters onto their lowercase unicode equivalent, which then affects you our your readers in the following way:
+> ⚠ **Important:** Vuepress maps headings onto section anchors which become part of a URL fragment like `http://.../#foo-anchor`. By default vuepress creates anchors with lowercase ASCII characters, only. In contrast github-slugger will map unicode characters onto their lowercase unicode equivalent, which then affects you our your readers in the following way:
 >
 > 1. Readers who bookmarked a section URL with an ASCII-only `#`-URL fragment will still be able to open the web page they've bookmarked. But as a minor inconvenience their browser may no longer scroll to the bookmarked page section.
 >
@@ -99,7 +95,7 @@ More information see [README.md](../README.md).
 
 ## Markdown Extensions
 
-Vuepress supports some [Markdown Syntax](https://vuepress.vuejs.org/guide/markdown.html) not covered by [CommonMark]. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with glossarify-md (see [Markdown Syntax Extensions][doc-syntax-extensions]).
+Vuepress supports some [Markdown Syntax](https://vuepress.vuejs.org/guide/markdown.html) not covered by CommonMark. While most of it will work out of the box, *Frontmatter Syntax* requires a plug-in to work with glossarify-md (see [Markdown Syntax Extensions][doc-syntax-extensions]).
 
 |      Vuepress Markdown Extension      |                   remark plug-in required with glossarify-md                   |
 | ------------------------------------- | ------------------------------------------------------------------------------ |
@@ -121,10 +117,10 @@ Vuepress supports some [Markdown Syntax](https://vuepress.vuejs.org/guide/markdo
 
 ## Appendix
 
-[glossarify-md] and [vuepress] both employ a slug algorithm to create friendly URL fragments (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different URL fragments which can break links in a book (see [#27](https://github.com/about-code/glossarify-md/issues/27)). To avoid this vuepress needs to be configured to use the same slugger as [glossarify-md].
+glossarify-md and vuepress both employ a slug algorithm to create friendly URL fragments (`#...`) for section links. When vuepress is fed with *glossarified markdown* sources it will attempt to slug URLs again. If both tools use different slug algorithms then there's a risk of both generating different URL fragments which can break links in a book (see [#27](https://github.com/about-code/glossarify-md/issues/27)). To avoid this vuepress needs to be configured to use the same slugger as glossarify-md.
 
 
-[glossarify-md] uses [github-slugger] internally. In case you want to get rid of [glossarify-md] you likely not want to have slugs change again. Then you can use [github-slugger] standalone with vuepress, like so:
+glossarify-md uses [github-slugger] internally. In case you want to get rid of glossarify-md you likely not want to have slugs change again. Then you can use [github-slugger] standalone with vuepress, like so:
 
 *Using github-slugger without glossarify-md*
 ```js


### PR DESCRIPTION
Use glossarify to link to external sources when mentioning tools or terms related to external websites.